### PR TITLE
feat: add GWT TUI and switch provider to Chat Completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ vite.config.ts.timestamp-*
 
 # User settings (created from settings.example.ts)
 settings.ts
+
+# Node Data
+/data

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,19 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "ink": "^7.1.0",
+        "marked": "^18.0.5",
         "openai": "^6.7.0",
         "p-queue": "^9.3.0",
         "p-retry": "^8.0.0",
-        "p-timeout": "^7.0.1"
+        "p-timeout": "^7.0.1",
+        "react": "^19.2.7"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",
         "@commitlint/config-conventional": "^21.0.1",
         "@types/node": "^25.9.3",
+        "@types/react": "^19.2.17",
         "@typescript-eslint/eslint-plugin": "^8.61.0",
         "@typescript-eslint/parser": "^8.60.1",
         "@vitest/coverage-v8": "^4.1.9",
@@ -27,9 +31,23 @@
         "eslint-plugin-prettier": "^5.5.6",
         "husky": "^9.1.7",
         "prettier": "^3.8.4",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.0",
         "vitest": "^4.1.9"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz",
+      "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -423,6 +441,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1067,6 +1527,16 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
@@ -1513,11 +1983,25 @@
         }
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1530,7 +2014,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1573,6 +2056,18 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/balanced-match": {
@@ -1680,6 +2175,77 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
+      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20 <19 || >=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.0.1.tgz",
+      "integrity": "sha512-2FPVnc3JxdRLONB/9edO1RwuUFFPJ3U2c6XvyccEhjqV5xw6mS22aH27OFdD1u4IYQOEUzXsT6ZU06d1VCSu+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^9.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -1693,6 +2259,18 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/compare-func": {
@@ -1777,6 +2355,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1871,6 +2458,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1974,6 +2568,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -2025,12 +2631,53 @@
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
       "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
-      "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2626,7 +3273,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2879,6 +3525,18 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2893,6 +3551,88 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ink": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-7.1.0.tgz",
+      "integrity": "sha512-VWE6/yeLtFCJBNLflyI2OSylyXK1Rc24LuXup8Qt+icwkmmycFNdbn8IkSp6Frc0h1iA0NOvvi1ajW44U/w3Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.3.0",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.3",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.2",
+        "cli-boxes": "^4.0.1",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^6.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.45.1",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^9.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.2.0",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.5.0",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^10.0.0",
+        "ws": "^8.20.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.2.0",
+        "react": ">=19.2.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/ip-address": {
@@ -2930,6 +3670,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2941,6 +3696,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-network-error": {
@@ -3457,6 +4227,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3523,6 +4305,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -3633,6 +4424,21 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/openai": {
@@ -3788,6 +4594,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-exists": {
@@ -3985,6 +4800,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4002,6 +4841,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rolldown": {
@@ -4058,6 +4913,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -4224,6 +5085,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
+      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4232,6 +5115,27 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stackback": {
@@ -4279,7 +5183,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -4318,6 +5221,30 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -4394,6 +5321,25 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4405,6 +5351,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -4711,6 +5672,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4744,6 +5736,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -4795,6 +5808,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "husky": "^9.1.7",
+        "ink-testing-library": "^4.0.0",
         "prettier": "^3.8.4",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3",
@@ -3598,6 +3599,24 @@
           "optional": true
         },
         "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "prebuild": "[ -f settings.ts ] && echo 'settings.ts already exists, skipping copy' || (cp settings.example.ts settings.ts && echo 'Created settings.ts from settings.example.ts')",
     "build": "tsc",
+    "tui": "tsx src/tui/index.tsx",
     "test": "vitest --run --coverage",
     "test:watch": "vitest",
     "clean": "rm -rf dist node_modules coverage settings.ts",
@@ -28,6 +29,7 @@
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.1",
     "@types/node": "^25.9.3",
+    "@types/react": "^19.2.17",
     "@typescript-eslint/eslint-plugin": "^8.61.0",
     "@typescript-eslint/parser": "^8.60.1",
     "@vitest/coverage-v8": "^4.1.9",
@@ -36,15 +38,19 @@
     "eslint-plugin-prettier": "^5.5.6",
     "husky": "^9.1.7",
     "prettier": "^3.8.4",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
     "vitest": "^4.1.9"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "ink": "^7.1.0",
+    "marked": "^18.0.5",
     "openai": "^6.7.0",
     "p-queue": "^9.3.0",
     "p-retry": "^8.0.0",
-    "p-timeout": "^7.0.1"
+    "p-timeout": "^7.0.1",
+    "react": "^19.2.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "husky": "^9.1.7",
+    "ink-testing-library": "^4.0.0",
     "prettier": "^3.8.4",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/src/adapter/queuing-open-ai.test.ts
+++ b/src/adapter/queuing-open-ai.test.ts
@@ -1,101 +1,99 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { QueuingOpenAi } from './queuing-open-ai.js';
 import { OpenAI } from 'openai';
+import { ChatCompletion } from 'openai/resources/chat/completions';
 import RequestOptions = OpenAI.RequestOptions;
 
+const chatCompletion = (id: string): ChatCompletion =>
+  ({ id, choices: [] }) as unknown as ChatCompletion;
+
 describe('QueuingOpenAi', () => {
-  let mockClient: { responses: { create: Mock } };
+  let mockClient: { chat: { completions: { create: Mock } } };
 
   beforeEach(() => {
     mockClient = {
-      responses: {
-        create: vi.fn(),
+      chat: {
+        completions: {
+          create: vi.fn(),
+        },
       },
     };
   });
 
-  it('should create a QueuingOpenAi instance with the given props', async () => {
+  it('should create a QueuingOpenAi instance with the given props', () => {
     const queuingClient = new QueuingOpenAi({
-      client: mockClient as unknown as import('openai').OpenAI,
+      client: mockClient as unknown as OpenAI,
       maxParallelism: 2,
       retryOptions: { retries: 3 },
       totalTimeout: 1000,
     });
 
-    expect(typeof queuingClient.responses.create).toBe('function');
+    expect(typeof queuingClient.chat.completions.create).toBe('function');
   });
 
   it('should queue requests and respect concurrency limit', async () => {
     let activeRequests = 0;
     let maxConcurrent = 0;
 
-    mockClient.responses.create.mockImplementation(() => {
+    mockClient.chat.completions.create.mockImplementation(() => {
       activeRequests++;
       maxConcurrent = Math.max(maxConcurrent, activeRequests);
-      return new Promise<import('openai/resources').Responses.Response>(
-        (resolve) => {
-          setTimeout(() => {
-            activeRequests--;
-            resolve({
-              output_text: 'test response',
-            } as import('openai/resources').Responses.Response);
-          }, 100);
-        },
-      );
+      return new Promise<ChatCompletion>((resolve) => {
+        setTimeout(() => {
+          activeRequests--;
+          resolve(chatCompletion('test'));
+        }, 100);
+      });
     });
 
     const queuingClient = new QueuingOpenAi({
-      client: mockClient as unknown as import('openai').OpenAI,
+      client: mockClient as unknown as OpenAI,
       maxParallelism: 2,
       retryOptions: { retries: 3 },
       totalTimeout: 1000,
     });
 
-    // Make 4 concurrent requests
     const promises = Array.from({ length: 4 }, () =>
-      queuingClient.responses.create({
+      queuingClient.chat.completions.create({
         model: 'test-model',
-        input: [{ role: 'user', content: 'test' }],
+        messages: [{ role: 'user', content: 'test' }],
       }),
     );
 
     await Promise.all(promises);
 
-    // Should never exceed maxParallelism of 2
     expect(maxConcurrent).toBe(2);
   });
 
   it('should return correct response from queued request', async () => {
-    const expectedResponse = {
-      output_text: 'Hello from queue!',
-    } as import('openai/resources').Responses.Response;
+    const expectedResponse = chatCompletion('hello-from-queue');
 
-    vi.mocked(mockClient.responses.create).mockResolvedValue(expectedResponse);
+    vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+      expectedResponse,
+    );
 
     const queuingClient = new QueuingOpenAi({
-      client: mockClient as unknown as import('openai').OpenAI,
+      client: mockClient as unknown as OpenAI,
       maxParallelism: 1,
       retryOptions: { retries: 3 },
       totalTimeout: 1000,
     });
 
-    const result = await queuingClient.responses.create({
+    const result = await queuingClient.chat.completions.create({
       model: 'test-model',
-      input: [{ role: 'user', content: 'test' }],
+      messages: [{ role: 'user', content: 'test' }],
     });
 
     expect(result).toBe(expectedResponse);
   });
 
   it('should pass through options parameter to client', async () => {
-    const mockResponse = {
-      output_text: 'response with options',
-    } as import('openai/resources').Responses.Response;
-
-    vi.mocked(mockClient.responses.create).mockResolvedValue(mockResponse);
+    vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+      chatCompletion('with-options'),
+    );
 
     const queuingClient = new QueuingOpenAi({
-      client: mockClient as unknown as import('openai').OpenAI,
+      client: mockClient as unknown as OpenAI,
       maxParallelism: 1,
       retryOptions: { retries: 3 },
       totalTimeout: 1000,
@@ -103,17 +101,17 @@ describe('QueuingOpenAi', () => {
 
     const options = { timeout: 5000 } as RequestOptions;
 
-    await queuingClient.responses.create(
+    await queuingClient.chat.completions.create(
       {
         model: 'test-model',
-        input: [{ role: 'user', content: 'test' }],
+        messages: [{ role: 'user', content: 'test' }],
       },
       options,
     );
 
     // Options are forwarded with an AbortSignal merged in so the overall
     // timeout can cancel the in-flight request.
-    expect(mockClient.responses.create).toHaveBeenCalledWith(
+    expect(mockClient.chat.completions.create).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         timeout: 5000,
@@ -123,134 +121,109 @@ describe('QueuingOpenAi', () => {
   });
 
   it('should retry on failure and eventually succeed', async () => {
-    const expectedResponse = {
-      output_text: 'success after retries!',
-    } as import('openai/resources').Responses.Response;
+    const expectedResponse = chatCompletion('success-after-retries');
 
-    vi.mocked(mockClient.responses.create)
+    vi.mocked(mockClient.chat.completions.create)
       .mockRejectedValueOnce(new Error('transient error'))
       .mockResolvedValueOnce(expectedResponse);
 
     const queuingClient = new QueuingOpenAi({
-      client: mockClient as unknown as import('openai').OpenAI,
+      client: mockClient as unknown as OpenAI,
       maxParallelism: 1,
       retryOptions: { retries: 2, minTimeout: 0 },
       totalTimeout: 1000,
     });
 
-    const result = await queuingClient.responses.create({
+    const result = await queuingClient.chat.completions.create({
       model: 'test-model',
-      input: [{ role: 'user', content: 'test' }],
+      messages: [{ role: 'user', content: 'test' }],
     });
 
     expect(result).toBe(expectedResponse);
-    expect(mockClient.responses.create).toHaveBeenCalledTimes(2);
+    expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(2);
   });
 
   it('should exhaust retries and throw error', async () => {
-    vi.mocked(mockClient.responses.create).mockRejectedValue(
+    vi.mocked(mockClient.chat.completions.create).mockRejectedValue(
       new Error('persistent error'),
     );
 
     const queuingClient = new QueuingOpenAi({
-      client: mockClient as unknown as import('openai').OpenAI,
+      client: mockClient as unknown as OpenAI,
       maxParallelism: 1,
       retryOptions: { retries: 2, minTimeout: 0 },
       totalTimeout: 1000,
     });
 
     await expect(
-      queuingClient.responses.create({
+      queuingClient.chat.completions.create({
         model: 'test-model',
-        input: [{ role: 'user', content: 'test' }],
+        messages: [{ role: 'user', content: 'test' }],
       }),
     ).rejects.toThrow('persistent error');
 
-    expect(mockClient.responses.create).toHaveBeenCalledTimes(3); // initial + 2 retries
+    expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(3);
   });
 
   it('should timeout if operation exceeds totalTimeout', async () => {
-    // Mock a very slow response
-    vi.mocked(mockClient.responses.create).mockImplementation(() => {
-      return new Promise<import('openai/resources').Responses.Response>(
-        (resolve) => {
-          setTimeout(
-            () =>
-              resolve({
-                output_text: 'too late',
-              } as import('openai/resources').Responses.Response),
-            1000,
-          );
-        },
-      );
+    vi.mocked(mockClient.chat.completions.create).mockImplementation(() => {
+      return new Promise<ChatCompletion>((resolve) => {
+        setTimeout(() => resolve(chatCompletion('too-late')), 1000);
+      });
     });
 
     const queuingClient = new QueuingOpenAi({
-      client: mockClient as unknown as import('openai').OpenAI,
-      maxParallelism: 1,
-      retryOptions: { retries: 3 },
-      totalTimeout: 100, // Very short timeout
-    });
-
-    await expect(
-      queuingClient.responses.create({
-        model: 'test-model',
-        input: [{ role: 'user', content: 'test' }],
-      }),
-    ).rejects.toThrow();
-  });
-
-  it('should release concurrency slot immediately after timeout', async () => {
-    vi.mocked(mockClient.responses.create).mockImplementation(() => {
-      return new Promise<import('openai/resources').Responses.Response>(
-        (resolve) => {
-          setTimeout(() => {
-            resolve({
-              output_text: 'done',
-            } as import('openai/resources').Responses.Response);
-          }, 1000);
-        },
-      );
-    });
-
-    const queuingClient = new QueuingOpenAi({
-      client: mockClient as unknown as import('openai').OpenAI,
+      client: mockClient as unknown as OpenAI,
       maxParallelism: 1,
       retryOptions: { retries: 3 },
       totalTimeout: 100,
     });
 
-    // Start first request (will timeout)
-    try {
-      await queuingClient.responses.create({
+    await expect(
+      queuingClient.chat.completions.create({
         model: 'test-model',
-        input: [{ role: 'user', content: 'test' }],
+        messages: [{ role: 'user', content: 'test' }],
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should release concurrency slot immediately after timeout', async () => {
+    vi.mocked(mockClient.chat.completions.create).mockImplementation(() => {
+      return new Promise<ChatCompletion>((resolve) => {
+        setTimeout(() => resolve(chatCompletion('done')), 1000);
+      });
+    });
+
+    const queuingClient = new QueuingOpenAi({
+      client: mockClient as unknown as OpenAI,
+      maxParallelism: 1,
+      retryOptions: { retries: 3 },
+      totalTimeout: 100,
+    });
+
+    try {
+      await queuingClient.chat.completions.create({
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
       });
       throw new Error('Should have timed out');
     } catch (e) {
       expect((e as Error).name).toMatch(/TimeoutError/);
     }
 
-    // The first request timed out at 100ms.
-    // If it was cancelled, the second request should be able to start immediately.
-    // If not, it will have to wait for the 1000ms timer of the first request to finish.
-
     const startTime = Date.now();
 
-    // Mock response for second request so we can measure how quickly it starts/finishes
-    vi.mocked(mockClient.responses.create).mockResolvedValueOnce({
-      output_text: 'second',
-    } as import('openai/resources').Responses.Response);
+    vi.mocked(mockClient.chat.completions.create).mockResolvedValueOnce(
+      chatCompletion('second'),
+    );
 
-    await queuingClient.responses.create({
+    await queuingClient.chat.completions.create({
       model: 'test-model',
-      input: [{ role: 'user', content: 'test' }],
+      messages: [{ role: 'user', content: 'test' }],
     });
 
     const duration = Date.now() - startTime;
 
-    // If cancelled, the second request should finish very quickly (much less than 1000ms).
-    // If not cancelled, it would wait at least 900ms more.
     expect(duration).toBeLessThan(500);
   });
 });

--- a/src/adapter/queuing-open-ai.ts
+++ b/src/adapter/queuing-open-ai.ts
@@ -1,5 +1,9 @@
 import { MinimalOpenAi } from '../types/provider.js';
 import { OpenAI } from 'openai';
+import {
+  ChatCompletion,
+  ChatCompletionCreateParamsNonStreaming,
+} from 'openai/resources/chat/completions';
 import PQueue from 'p-queue';
 import pRetry, { Options as RetryOptions } from 'p-retry';
 import pTimeout from 'p-timeout';
@@ -18,43 +22,45 @@ export class QueuingOpenAi implements MinimalOpenAi {
     this.queue = new PQueue({ concurrency: props.maxParallelism });
   }
 
-  public readonly responses: MinimalOpenAi['responses'] = {
-    create: async (
-      body: OpenAI.Responses.ResponseCreateParamsNonStreaming,
-      options?: OpenAI.RequestOptions,
-    ): Promise<OpenAI.Responses.Response> => {
-      const controller = new AbortController();
-      const signal = controller.signal;
+  public readonly chat: MinimalOpenAi['chat'] = {
+    completions: {
+      create: async (
+        body: ChatCompletionCreateParamsNonStreaming,
+        options?: OpenAI.RequestOptions,
+      ): Promise<ChatCompletion> => {
+        const controller = new AbortController();
+        const signal = controller.signal;
 
-      const operation = async () => {
-        return this.queue.add(async () => {
-          return pTimeout(
-            pRetry(
-              () =>
-                this.props.client.responses.create(body, {
-                  ...options,
+        const operation = async () => {
+          return this.queue.add(async () => {
+            return pTimeout(
+              pRetry(
+                () =>
+                  this.props.client.chat.completions.create(body, {
+                    ...options,
+                    signal,
+                  }),
+                {
+                  ...this.props.retryOptions,
                   signal,
-                }),
+                },
+              ),
               {
-                ...this.props.retryOptions,
-                signal,
+                milliseconds: this.props.totalTimeout,
               },
-            ),
-            {
-              milliseconds: this.props.totalTimeout,
-            },
-          );
-        });
-      };
+            );
+          });
+        };
 
-      try {
-        return await operation();
-      } catch (e) {
-        // On timeout (or any failure) abort the in-flight request so it does
-        // not run on detached after we have already rejected.
-        controller.abort();
-        throw e;
-      }
+        try {
+          return await operation();
+        } catch (e) {
+          // On timeout (or any failure) abort the in-flight request so it does
+          // not run on detached after we have already rejected.
+          controller.abort();
+          throw e;
+        }
+      },
     },
   };
 }

--- a/src/constants/initialization.ts
+++ b/src/constants/initialization.ts
@@ -90,7 +90,15 @@ const setupLoggingSubscribers = (eventStream: EventStream): void => {
 
 const DEFAULT_OPENAI_TIMEOUT_MS = 60_000;
 
-export const init = async () => {
+export interface InitOptions {
+  /**
+   * Attach the console.info logging subscribers. Defaults to true.
+   * The TUI sets this to false so log output doesn't fight Ink for the screen.
+   */
+  readonly attachConsoleLogging?: boolean;
+}
+
+export const init = async (options?: InitOptions) => {
   const settings: LegionSettings = rawSettings;
   const openAiTimeout = settings.openAiTimeout ?? DEFAULT_OPENAI_TIMEOUT_MS;
 
@@ -117,7 +125,9 @@ export const init = async () => {
   const eventStream = new ConcreteEventStream();
 
   // Setup logging subscribers to see what's happening
-  setupLoggingSubscribers(eventStream);
+  if (options?.attachConsoleLogging ?? true) {
+    setupLoggingSubscribers(eventStream);
+  }
 
   // Try to load a session if saveLocation is configured
   let loadedSession: LoadedSession | undefined;
@@ -261,5 +271,6 @@ export const init = async () => {
   return {
     orchestrator,
     mcpClients,
+    eventStream,
   };
 };

--- a/src/orchestration/epoch-orchestrator.test.ts
+++ b/src/orchestration/epoch-orchestrator.test.ts
@@ -648,6 +648,80 @@ describe('EpochOrchestrator', () => {
     );
   });
 
+  it('should inject a broadcast into the global workspace', () => {
+    const orchestrator = new EpochOrchestrator({
+      provider: mockProvider,
+      relevanceFilter: mockRelevanceFilter,
+      distiller: mockDistiller,
+      maxWorkingMemoryMessages: 10,
+      initialBroadcast: { content: 'Initial broadcast' },
+      memoryNodeFactory: mockMemoryNodeFactory,
+      contextLengthThreshold: 1000,
+      memoryNodeSplitter: mockMemoryNodeSplitter,
+      nodePruner: mockNodePruner,
+      eventStream,
+    });
+
+    let publishedBroadcast: string | undefined;
+    eventStream.subscribe({
+      topicName: 'orchestrator/working-memory-updated',
+      receiver: (data) => {
+        publishedBroadcast = data.broadcast.content;
+      },
+    });
+
+    orchestrator.injectBroadcast('User typed this');
+
+    expect(orchestrator.currentBroadcast.content).toBe('User typed this');
+    expect(publishedBroadcast).toBe('User typed this');
+  });
+
+  it('should use an injected broadcast on the next epoch', async () => {
+    const orchestrator = new EpochOrchestrator({
+      provider: mockProvider,
+      relevanceFilter: mockRelevanceFilter,
+      distiller: mockDistiller,
+      maxWorkingMemoryMessages: 10,
+      initialBroadcast: { content: 'Initial broadcast' },
+      memoryNodeFactory: mockMemoryNodeFactory,
+      contextLengthThreshold: 1000,
+      memoryNodeSplitter: mockMemoryNodeSplitter,
+      nodePruner: mockNodePruner,
+      eventStream,
+    });
+
+    const sendMessageSpy = vi.fn();
+    sendMessageSpy.mockResolvedValue({
+      originatingNodeId: 'node-a',
+      content: 'Response',
+    });
+    const nodeA: Node<'memory'> = {
+      id: 'node-a',
+      kind: 'memory' as const,
+      status: 'idle',
+      context: 'Context for node-a',
+      sendMessage: sendMessageSpy,
+    };
+    orchestrator.addNode(nodeA);
+
+    vi.mocked(mockRelevanceFilter.filter).mockResolvedValue([
+      { content: 'Response', originatingNodeId: 'node-a' },
+    ]);
+    vi.mocked(mockDistiller.distill).mockResolvedValue('Distilled insight');
+
+    orchestrator.injectBroadcast('Hello workspace');
+    await orchestrator.runEpoch();
+
+    // The injected message is what nodes received this epoch.
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        broadcast: expect.objectContaining({ content: 'Hello workspace' }),
+      }),
+    );
+    // The pending injection was consumed; the epoch then distilled normally.
+    expect(orchestrator.currentBroadcast.content).toBe('Distilled insight');
+  });
+
   it('should spawn a new node when all candidates return undefined', async () => {
     const initialWM: WorkingMemory = {
       messages: [{ content: 'Existing message' }],

--- a/src/orchestration/epoch-orchestrator.ts
+++ b/src/orchestration/epoch-orchestrator.ts
@@ -43,6 +43,7 @@ interface EpochCandidates {
 
 export class EpochOrchestrator {
   private _currentBroadcast: Message;
+  private _pendingInjection: string | undefined = undefined;
   private readonly _registry: NodeRegistry;
   private readonly _workingMemory: WorkingMemoryBuffer;
 
@@ -84,7 +85,28 @@ export class EpochOrchestrator {
     return this._currentBroadcast;
   }
 
+  /**
+   * Inject an external message into the global workspace. It becomes the
+   * spotlight broadcast for the next epoch. Queued via `_pendingInjection` so
+   * it survives an in-flight epoch's end-of-epoch distillation overwrite.
+   */
+  public readonly injectBroadcast = (content: string): void => {
+    this._pendingInjection = content;
+    this._currentBroadcast = { content };
+    this.props.eventStream.publish({
+      topicName: 'orchestrator/working-memory-updated',
+      data: {
+        workingMemory: this.workingMemory,
+        broadcast: this.currentBroadcast,
+      },
+    });
+  };
+
   public readonly runEpoch = async (): Promise<void> => {
+    if (this._pendingInjection !== undefined) {
+      this._currentBroadcast = { content: this._pendingInjection };
+      this._pendingInjection = undefined;
+    }
     // Afferent wave: tools and sensors perceive first. Their output is context
     // for the cognitive wave, never a broadcast candidate, so it bypasses the
     // relevance filter entirely (no upstream bottleneck on perception).

--- a/src/provider/openai-provider.test.ts
+++ b/src/provider/openai-provider.test.ts
@@ -1,19 +1,41 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { OpenaiProvider } from './openai-provider.js';
 import { OpenAI } from 'openai';
+import { ChatCompletion } from 'openai/resources/chat/completions';
+
+/** Build a minimal ChatCompletion with a single choice. */
+const completion = (
+  content: string | null,
+  toolCalls?: unknown[],
+): ChatCompletion =>
+  ({
+    choices: [
+      {
+        message: {
+          content,
+          ...(toolCalls !== undefined ? { tool_calls: toolCalls } : {}),
+        },
+      },
+    ],
+  }) as unknown as ChatCompletion;
+
+const noChoices = (): ChatCompletion =>
+  ({ choices: [] }) as unknown as ChatCompletion;
 
 describe('OpenaiProvider', () => {
-  let mockClient: { responses: { create: Mock } };
+  let mockClient: { chat: { completions: { create: Mock } } };
 
   beforeEach(() => {
     mockClient = {
-      responses: {
-        create: vi.fn(),
+      chat: {
+        completions: {
+          create: vi.fn(),
+        },
       },
     };
   });
 
-  it('should create a provider with the given props', async () => {
+  it('should create a provider with the given props', () => {
     const provider = new OpenaiProvider({
       model: 'test-model',
       client: mockClient as unknown as OpenAI,
@@ -22,177 +44,150 @@ describe('OpenaiProvider', () => {
     expect(typeof provider.generate).toBe('function');
   });
 
-  it('should call responses.create with correct input including system prompt', async () => {
-    const props = {
-      systemPrompt: 'You are a helpful assistant.',
-      messages: [
-        { content: 'Hello, how are you?' },
-        { content: 'I am doing well, thanks!' },
-      ],
-    };
+  describe('generate', () => {
+    it('should send system + user messages and return content', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion('Hi there! I am a test response.'),
+      );
 
-    const responseText = 'Hi there! I am a test response.';
+      const provider = new OpenaiProvider({
+        model: 'test-model',
+        client: mockClient as unknown as OpenAI,
+      });
 
-    vi.mocked(mockClient.responses.create).mockResolvedValue({
-      output_text: responseText,
+      const result = await provider.generate({
+        systemPrompt: 'You are a helpful assistant.',
+        messages: [
+          { content: 'Hello, how are you?' },
+          { content: 'I am doing well, thanks!' },
+        ],
+      });
+
+      expect(mockClient.chat.completions.create).toHaveBeenCalledWith({
+        model: 'test-model',
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant.' },
+          { role: 'user', content: 'Hello, how are you?' },
+          { role: 'user', content: 'I am doing well, thanks!' },
+        ],
+      });
+      expect(result).toBe('Hi there! I am a test response.');
     });
 
-    const provider = new OpenaiProvider({
-      model: 'test-model',
-      client: mockClient as unknown as OpenAI,
+    it('should synthesize a user turn when no messages are provided', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion('Distilled output'),
+      );
+
+      const provider = new OpenaiProvider({
+        model: 'test-model',
+        client: mockClient as unknown as OpenAI,
+      });
+
+      const result = await provider.generate({
+        systemPrompt: 'Everything is in the system prompt.',
+        messages: [],
+      });
+
+      expect(mockClient.chat.completions.create).toHaveBeenCalledWith({
+        model: 'test-model',
+        messages: [
+          { role: 'system', content: 'Everything is in the system prompt.' },
+          {
+            role: 'user',
+            content: 'Produce the output now, following the instructions above.',
+          },
+        ],
+      });
+      expect(result).toBe('Distilled output');
     });
 
-    const result = await provider.generate(props);
+    it('should return empty string when there are no choices', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        noChoices(),
+      );
 
-    expect(mockClient.responses.create).toHaveBeenCalledWith({
-      model: 'test-model',
-      input: [
-        { role: 'system', content: 'You are a helpful assistant.' },
-        { role: 'user', content: 'Hello, how are you?' },
-        { role: 'user', content: 'I am doing well, thanks!' },
-      ],
+      const provider = new OpenaiProvider({
+        model: 'test-model',
+        client: mockClient as unknown as OpenAI,
+      });
+
+      const result = await provider.generate({
+        systemPrompt: 'test',
+        messages: [{ content: 'test' }],
+      });
+
+      expect(result).toBe('');
     });
 
-    expect(result).toBe(responseText);
-  });
+    it('should return empty string when message content is null', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion(null),
+      );
 
-  it('should return empty string when response has no output_text', async () => {
-    vi.mocked(mockClient.responses.create).mockResolvedValue({
-      output_text: null,
+      const provider = new OpenaiProvider({
+        model: 'test-model',
+        client: mockClient as unknown as OpenAI,
+      });
+
+      const result = await provider.generate({
+        systemPrompt: 'test',
+        messages: [{ content: 'test' }],
+      });
+
+      expect(result).toBe('');
     });
-
-    const provider = new OpenaiProvider({
-      model: 'test-model',
-      client: mockClient as unknown as OpenAI,
-    });
-
-    const result = await provider.generate({
-      systemPrompt: 'test',
-      messages: [{ content: 'test' }],
-    });
-
-    expect(result).toBe('');
-  });
-
-  it('should handle single message input', async () => {
-    vi.mocked(mockClient.responses.create).mockResolvedValue({
-      output_text: 'Single message response',
-    });
-
-    const provider = new OpenaiProvider({
-      model: 'test-model',
-      client: mockClient as unknown as OpenAI,
-    });
-
-    const result = await provider.generate({
-      systemPrompt: 'System prompt',
-      messages: [{ content: 'Only one message' }],
-    });
-
-    expect(mockClient.responses.create).toHaveBeenCalledWith({
-      model: 'test-model',
-      input: [
-        { role: 'system', content: 'System prompt' },
-        { role: 'user', content: 'Only one message' },
-      ],
-    });
-
-    expect(result).toBe('Single message response');
   });
 
   describe('rankByRelevance', () => {
     it('should rank items by relevance and return indices', async () => {
-      const concept = 'fruit';
-      const items = ['apple', 'carrot', 'banana'];
-
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: JSON.stringify({ rankedIndices: [0, 2, 1] }),
-      });
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion(JSON.stringify({ rankedIndices: [0, 2, 1] })),
+      );
 
       const provider = new OpenaiProvider({
         model: 'test-model',
         client: mockClient as unknown as OpenAI,
       });
 
-      const result = await provider.rankByRelevance(concept, items);
+      const result = await provider.rankByRelevance('fruit', [
+        'apple',
+        'carrot',
+        'banana',
+      ]);
 
-      expect(mockClient.responses.create).toHaveBeenCalledWith({
-        model: 'test-model',
-        temperature: 0,
-        input: [
-          { role: 'system', content: expect.any(String) },
-          { role: 'user', content: expect.stringContaining('fruit') },
-        ],
-        text: {
-          format: {
+      expect(mockClient.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'test-model',
+          temperature: 0,
+          messages: [
+            expect.objectContaining({ role: 'system' }),
+            expect.objectContaining({
+              role: 'user',
+              content: expect.stringContaining('fruit'),
+            }),
+          ],
+          response_format: {
             type: 'json_schema',
-            name: 'ranking',
-            schema: expect.objectContaining({
-              properties: { rankedIndices: expect.any(Object) },
-              required: ['rankedIndices'],
+            json_schema: expect.objectContaining({
+              name: 'ranking',
+              strict: true,
+              schema: expect.objectContaining({
+                required: ['rankedIndices'],
+              }),
             }),
           },
-        },
-      });
-
-      expect(result).toEqual([0, 2, 1]);
-    });
-
-    it('should handle empty items array', async () => {
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: JSON.stringify({ rankedIndices: [] }),
-      });
-
-      const provider = new OpenaiProvider({
-        model: 'test-model',
-        client: mockClient as unknown as OpenAI,
-      });
-
-      const result = await provider.rankByRelevance('concept', []);
-
-      expect(result).toEqual([]);
-    });
-
-    it('should handle single item array', async () => {
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: JSON.stringify({ rankedIndices: [0] }),
-      });
-
-      const provider = new OpenaiProvider({
-        model: 'test-model',
-        client: mockClient as unknown as OpenAI,
-      });
-
-      const result = await provider.rankByRelevance('concept', ['only item']);
-
-      expect(result).toEqual([0]);
-    });
-
-    it('should use correct temperature (0) for deterministic ranking', async () => {
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: JSON.stringify({ rankedIndices: [1, 0] }),
-      });
-
-      const provider = new OpenaiProvider({
-        model: 'test-model',
-        client: mockClient as unknown as OpenAI,
-      });
-
-      await provider.rankByRelevance('test', ['a', 'b']);
-
-      expect(mockClient.responses.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          temperature: 0,
         }),
       );
+      expect(result).toEqual([0, 2, 1]);
     });
   });
 
   describe('askYesNoQuestion', () => {
-    it('should return true for yes answers', async () => {
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: JSON.stringify({ answer: true }),
-      });
+    it('should return true and include the cacheable prefix, messages, and question', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion(JSON.stringify({ answer: true })),
+      );
 
       const provider = new OpenaiProvider({
         model: 'test-model',
@@ -200,38 +195,35 @@ describe('OpenaiProvider', () => {
       });
 
       const result = await provider.askYesNoQuestion({
-        systemPrompt: 'You are a node.',
-        messages: [{ content: 'Some working memory' }],
-        question: 'Is this a test?',
+        systemPrompt: 'You are node 42.',
+        messages: [{ content: 'Working memory snapshot' }],
+        question: 'Is this relevant?',
       });
 
-      expect(mockClient.responses.create).toHaveBeenCalledWith({
-        model: 'test-model',
-        temperature: 0,
-        input: [
-          { role: 'system', content: 'You are a node.' },
-          { role: 'user', content: 'Some working memory' },
-          { role: 'user', content: expect.stringContaining('Is this a test?') },
-        ],
-        text: {
-          format: {
-            type: 'json_schema',
-            name: 'yes_no_answer',
-            schema: expect.objectContaining({
-              properties: { answer: expect.any(Object) },
-              required: ['answer'],
+      expect(mockClient.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 0,
+          messages: [
+            { role: 'system', content: 'You are node 42.' },
+            { role: 'user', content: 'Working memory snapshot' },
+            expect.objectContaining({
+              role: 'user',
+              content: expect.stringContaining('Is this relevant?'),
             }),
+          ],
+          response_format: {
+            type: 'json_schema',
+            json_schema: expect.objectContaining({ name: 'yes_no_answer' }),
           },
-        },
-      });
-
+        }),
+      );
       expect(result).toBe(true);
     });
 
     it('should return false for no answers', async () => {
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: JSON.stringify({ answer: false }),
-      });
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion(JSON.stringify({ answer: false })),
+      );
 
       const provider = new OpenaiProvider({
         model: 'test-model',
@@ -239,7 +231,7 @@ describe('OpenaiProvider', () => {
       });
 
       const result = await provider.askYesNoQuestion({
-        systemPrompt: 'You are a node.',
+        systemPrompt: 'sys',
         messages: [],
         question: 'Is this a test?',
       });
@@ -248,9 +240,9 @@ describe('OpenaiProvider', () => {
     });
 
     it('throws a descriptive error when the model returns no output', async () => {
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: undefined,
-      });
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion(null),
+      );
 
       const provider = new OpenaiProvider({
         model: 'test-model',
@@ -259,7 +251,7 @@ describe('OpenaiProvider', () => {
 
       await expect(
         provider.askYesNoQuestion({
-          systemPrompt: 'You are a node.',
+          systemPrompt: 'sys',
           messages: [],
           question: 'Is this a test?',
         }),
@@ -267,9 +259,9 @@ describe('OpenaiProvider', () => {
     });
 
     it('throws a descriptive error when the output is not valid JSON', async () => {
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: 'not json at all',
-      });
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion('not json at all'),
+      );
 
       const provider = new OpenaiProvider({
         model: 'test-model',
@@ -278,338 +270,184 @@ describe('OpenaiProvider', () => {
 
       await expect(
         provider.askYesNoQuestion({
-          systemPrompt: 'You are a node.',
+          systemPrompt: 'sys',
           messages: [],
           question: 'Is this a test?',
         }),
       ).rejects.toThrow('failed to parse structured output');
     });
+  });
 
-    describe('generateWithTools', () => {
-      it('should call responses.create with tools and return tool calls when present', async () => {
-        const props = {
-          systemPrompt: 'You are a helpful assistant.',
-          messages: [{ content: 'What is the weather?' }],
-          tools: [
-            {
-              name: 'get_weather',
-              description: 'Get current weather',
-              parameters: {
-                type: 'object',
-                properties: { location: { type: 'string' } },
-              },
-            },
-          ],
-        };
+  describe('splitString', () => {
+    it('should split content into two parts', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion(JSON.stringify({ left: 'A', right: 'B' })),
+      );
 
-        vi.mocked(mockClient.responses.create).mockResolvedValue({
-          output_text: null,
-          output: [
-            {
-              type: 'function_call',
-              call_id: 'call_123',
-              name: 'get_weather',
-              // The Responses API returns arguments as a JSON string.
-              arguments: '{"location":"San Francisco"}',
-            },
-          ],
-        });
+      const provider = new OpenaiProvider({
+        model: 'test-model',
+        client: mockClient as unknown as OpenAI,
+      });
 
-        const provider = new OpenaiProvider({
-          model: 'test-model',
-          client: mockClient as unknown as OpenAI,
-        });
+      const result = await provider.splitString('test content');
 
-        const result = await provider.generateWithTools(props);
+      expect(mockClient.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 0,
+          response_format: {
+            type: 'json_schema',
+            json_schema: expect.objectContaining({ name: 'split_output' }),
+          },
+        }),
+      );
+      expect(result).toEqual(['A', 'B']);
+    });
+  });
 
-        // The schema lacks additionalProperties:false and required, so strict
-        // mode must be disabled to avoid the API rejecting the tool.
-        expect(mockClient.responses.create).toHaveBeenCalledWith(
-          expect.objectContaining({
-            tools: [
-              {
-                type: 'function',
-                name: 'get_weather',
-                description: 'Get current weather',
-                parameters: expect.any(Object),
-                strict: false,
-              },
-            ],
-          }),
-        );
-
-        expect(result.content).toBe('');
-        expect(result.toolCalls).toEqual([
+  describe('generateWithTools', () => {
+    it('should map tools (strict when eligible) and return function tool calls', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion(null, [
           {
             id: 'call_123',
             type: 'function',
             function: {
-              // Passed through unchanged; not re-stringified.
               name: 'get_weather',
               arguments: '{"location":"San Francisco"}',
             },
           },
-        ]);
+        ]),
+      );
+
+      const provider = new OpenaiProvider({
+        model: 'test-model',
+        client: mockClient as unknown as OpenAI,
       });
 
-      it('should enable strict mode for a fully compliant tool schema', async () => {
-        vi.mocked(mockClient.responses.create).mockResolvedValue({
-          output_text: '',
-          output: [],
-        });
-
-        const provider = new OpenaiProvider({
-          model: 'test-model',
-          client: mockClient as unknown as OpenAI,
-        });
-
-        await provider.generateWithTools({
-          systemPrompt: 'You are a helpful assistant.',
-          messages: [{ content: 'What is the weather?' }],
-          tools: [
-            {
-              name: 'get_weather',
-              description: 'Get current weather',
-              parameters: {
-                type: 'object',
-                additionalProperties: false,
-                properties: { location: { type: 'string' } },
-                required: ['location'],
-              },
+      const result = await provider.generateWithTools({
+        systemPrompt: 'You are a helpful assistant.',
+        messages: [{ content: 'What is the weather?' }],
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Get current weather',
+            // Strict-eligible: additionalProperties:false + all props required.
+            parameters: {
+              type: 'object',
+              properties: { location: { type: 'string' } },
+              required: ['location'],
+              additionalProperties: false,
             },
-          ],
-        });
-
-        expect(mockClient.responses.create).toHaveBeenCalledWith(
-          expect.objectContaining({
-            tools: [expect.objectContaining({ strict: true })],
-          }),
-        );
+          },
+        ],
       });
 
-      it('should handle empty tools array', async () => {
-        vi.mocked(mockClient.responses.create).mockResolvedValue({
-          output_text: 'Response without tools',
-          output: [],
-        });
-
-        const provider = new OpenaiProvider({
-          model: 'test-model',
-          client: mockClient as unknown as OpenAI,
-        });
-
-        const result = await provider.generateWithTools({
-          systemPrompt: 'You are a helpful assistant.',
-          messages: [{ content: 'Hello!' }],
-          tools: [],
-        });
-
-        // Empty array should be passed to API (tools is now required in interface)
-        expect(mockClient.responses.create).toHaveBeenCalledWith(
-          expect.objectContaining({ tools: [] }),
-        );
-        expect(result.content).toBe('Response without tools');
-      });
-
-      it('should handle tool without description or parameters', async () => {
-        vi.mocked(mockClient.responses.create).mockResolvedValue({
-          output_text: 'Response with minimal tool',
-          output: [],
-        });
-
-        const provider = new OpenaiProvider({
-          model: 'test-model',
-          client: mockClient as unknown as OpenAI,
-        });
-
-        await provider.generateWithTools({
-          systemPrompt: 'You are a helpful assistant.',
-          messages: [{ content: 'Hello!' }],
-          tools: [
-            {
-              name: 'minimal_tool',
-              parameters: {
-                type: 'object',
-                properties: {},
-              },
-            },
-          ],
-        });
-
-        // Verify the tool was mapped with null description
-        expect(mockClient.responses.create).toHaveBeenCalledWith(
-          expect.objectContaining({
-            tools: [
-              expect.objectContaining({
-                name: 'minimal_tool',
-                description: null,
-              }),
-            ],
-          }),
-        );
-      });
-
-      it('should handle multiple tool calls in response', async () => {
-        vi.mocked(mockClient.responses.create).mockResolvedValue({
-          output_text: null,
-          output: [
-            {
-              type: 'function_call',
-              call_id: 'call_1',
-              name: 'tool_a',
-              arguments: '{"param":"value_a"}',
-            },
-            {
-              type: 'function_call',
-              call_id: 'call_2',
-              name: 'tool_b',
-              arguments: '{"param":"value_b"}',
-            },
-          ],
-        });
-
-        const provider = new OpenaiProvider({
-          model: 'test-model',
-          client: mockClient as unknown as OpenAI,
-        });
-
-        const result = await provider.generateWithTools({
-          systemPrompt: 'You are a helpful assistant.',
-          messages: [{ content: 'Use multiple tools' }],
-          tools: [],
-        });
-
-        expect(result.toolCalls).toHaveLength(2);
-        expect(result.toolCalls?.[0]).toEqual(
-          expect.objectContaining({
-            id: 'call_1',
-            function: expect.objectContaining({ name: 'tool_a' }),
-          }),
-        );
-        expect(result.toolCalls?.[1]).toEqual(
-          expect.objectContaining({
-            id: 'call_2',
-            function: expect.objectContaining({ name: 'tool_b' }),
-          }),
-        );
-      });
-
-      it('should handle messages with originatingNodeId as tool role', async () => {
-        vi.mocked(mockClient.responses.create).mockResolvedValue({
-          output_text: 'Response after tool call',
-          output: [],
-        });
-
-        const provider = new OpenaiProvider({
-          model: 'test-model',
-          client: mockClient as unknown as OpenAI,
-        });
-
-        await provider.generateWithTools({
-          systemPrompt: 'You are a helpful assistant.',
+      expect(mockClient.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tool_choice: 'required',
           messages: [
-            { content: 'What is the weather?' },
+            expect.objectContaining({ role: 'system' }),
+            expect.objectContaining({ role: 'user' }),
+          ],
+          tools: [
             {
-              originatingNodeId: 'node-123',
-              content: 'The weather is sunny',
+              type: 'function',
+              function: {
+                name: 'get_weather',
+                description: 'Get current weather',
+                parameters: expect.any(Object),
+                strict: true,
+              },
             },
           ],
-          tools: [],
-        });
-
-        expect(mockClient.responses.create).toHaveBeenCalledWith(
-          expect.objectContaining({
-            input: expect.arrayContaining([
-              expect.objectContaining({ role: 'system' }),
-              expect.objectContaining({ role: 'user' }),
-            ]),
-          }),
-        );
-      });
-
-      it('should handle non-array response output', async () => {
-        vi.mocked(mockClient.responses.create).mockResolvedValue({
-          output_text: 'Response with non-array output',
-          output: null,
-        });
-
-        const provider = new OpenaiProvider({
-          model: 'test-model',
-          client: mockClient as unknown as OpenAI,
-        });
-
-        const result = await provider.generateWithTools({
-          systemPrompt: 'You are a helpful assistant.',
-          messages: [{ content: 'Hello!' }],
-          tools: [],
-        });
-
-        expect(result.content).toBe('Response with non-array output');
-        expect(result.toolCalls).toBeUndefined();
-      });
-
-      it('should handle array response without tool calls', async () => {
-        vi.mocked(mockClient.responses.create).mockResolvedValue({
-          output_text: 'Response with empty tools',
-          output: [{}], // Array but no tool call items
-        });
-
-        const provider = new OpenaiProvider({
-          model: 'test-model',
-          client: mockClient as unknown as OpenAI,
-        });
-
-        const result = await provider.generateWithTools({
-          systemPrompt: 'You are a helpful assistant.',
-          messages: [{ content: 'Hello!' }],
-          tools: [],
-        });
-
-        expect(result.content).toBe('Response with empty tools');
-        expect(result.toolCalls).toBeUndefined();
-      });
+        }),
+      );
+      expect(result.content).toBe('');
+      expect(result.toolCalls).toEqual([
+        {
+          id: 'call_123',
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            arguments: '{"location":"San Francisco"}',
+          },
+        },
+      ]);
     });
 
-    it('should use correct temperature (0) for deterministic yes/no answers', async () => {
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: JSON.stringify({ answer: true }),
-      });
+    it('should omit description and disable strict for a non-compliant tool, and return no tool calls', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion('Response without tools'),
+      );
 
       const provider = new OpenaiProvider({
         model: 'test-model',
         client: mockClient as unknown as OpenAI,
       });
 
-      await provider.askYesNoQuestion({
-        systemPrompt: 'You are a node.',
-        messages: [],
-        question: 'Test question',
+      const result = await provider.generateWithTools({
+        systemPrompt: 'You are a helpful assistant.',
+        messages: [{ content: 'Hello!' }],
+        tools: [
+          {
+            name: 'minimal_tool',
+            parameters: { type: 'object', properties: {} },
+          },
+        ],
       });
 
-      expect(mockClient.responses.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          temperature: 0,
-        }),
-      );
+      const sentTool =
+        mockClient.chat.completions.create.mock.calls[0]![0].tools[0];
+      expect(sentTool.function.name).toBe('minimal_tool');
+      expect(sentTool.function).not.toHaveProperty('description');
+      expect(sentTool.function.strict).toBe(false);
+      expect(result.content).toBe('Response without tools');
+      expect(result.toolCalls).toBeUndefined();
     });
 
-    it('should use correct temperature (0) for deterministic string splitting', async () => {
-      vi.mocked(mockClient.responses.create).mockResolvedValue({
-        output_text: JSON.stringify({ left: 'A', right: 'B' }),
-      });
+    it('should return undefined tool calls when there are no choices', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        noChoices(),
+      );
 
       const provider = new OpenaiProvider({
         model: 'test-model',
         client: mockClient as unknown as OpenAI,
       });
 
-      await provider.splitString('test');
+      const result = await provider.generateWithTools({
+        systemPrompt: 'You are a helpful assistant.',
+        messages: [{ content: 'Hello!' }],
+        tools: [],
+      });
 
-      expect(mockClient.responses.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          temperature: 0,
-        }),
+      expect(result.content).toBe('');
+      expect(result.toolCalls).toBeUndefined();
+    });
+
+    it('should ignore non-function (custom) tool calls', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue(
+        completion('', [
+          {
+            id: 'call_custom',
+            type: 'custom',
+            custom: { name: 'do_thing', input: 'payload' },
+          },
+        ]),
       );
+
+      const provider = new OpenaiProvider({
+        model: 'test-model',
+        client: mockClient as unknown as OpenAI,
+      });
+
+      const result = await provider.generateWithTools({
+        systemPrompt: 'You are a helpful assistant.',
+        messages: [{ content: 'Hello!' }],
+        tools: [],
+      });
+
+      expect(result.toolCalls).toBeUndefined();
     });
   });
 });

--- a/src/provider/openai-provider.test.ts
+++ b/src/provider/openai-provider.test.ts
@@ -95,7 +95,8 @@ describe('OpenaiProvider', () => {
           { role: 'system', content: 'Everything is in the system prompt.' },
           {
             role: 'user',
-            content: 'Produce the output now, following the instructions above.',
+            content:
+              'Produce the output now, following the instructions above.',
           },
         ],
       });

--- a/src/provider/openai-provider.ts
+++ b/src/provider/openai-provider.ts
@@ -7,7 +7,11 @@ import {
   ToolCall,
   ToolDefinition,
 } from '../types/provider.js';
-import { OpenAI } from 'openai';
+import {
+  ChatCompletion,
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+} from 'openai/resources/chat/completions';
 import { isStrictEligible } from '../utilities/is-strict-eligible.js';
 
 export interface OpenAiProviderProps {
@@ -18,53 +22,76 @@ export interface OpenAiProviderProps {
 export class OpenaiProvider implements Provider {
   constructor(private readonly props: OpenAiProviderProps) {}
 
-  public readonly generate = async (props: GenerateProps): Promise<string> => {
-    const inputItems = [
-      {
-        role: 'system' as const,
-        content: props.systemPrompt,
-      },
-      ...props.messages.map((m) => ({
-        role: 'user' as const,
-        content: m.content,
-      })),
+  /** Text of the first choice, or '' when absent/null. */
+  private readonly firstContent = (response: ChatCompletion): string => {
+    const choice = response.choices[0];
+    return choice ? (choice.message.content ?? '') : '';
+  };
+
+  /**
+   * System prompt + the caller's messages as user turns. Chat-templated models
+   * reject prompts with no user turn, so when the caller puts the whole task in
+   * the system prompt and passes no messages (e.g. the distiller), a minimal
+   * user turn is synthesized.
+   */
+  private readonly buildMessages = (
+    systemPrompt: string,
+    messages: readonly { content: string }[],
+  ): ChatCompletionMessageParam[] => {
+    const items: ChatCompletionMessageParam[] = [
+      { role: 'system', content: systemPrompt },
+      ...messages.map(
+        (m): ChatCompletionMessageParam => ({
+          role: 'user',
+          content: m.content,
+        }),
+      ),
     ];
+    if (messages.length === 0) {
+      items.push({
+        role: 'user',
+        content: 'Produce the output now, following the instructions above.',
+      });
+    }
+    return items;
+  };
 
-    const response = await this.props.client.responses.create({
+  public readonly generate = async (props: GenerateProps): Promise<string> => {
+    const response = await this.props.client.chat.completions.create({
       model: this.props.model,
-      input: inputItems satisfies OpenAI.Responses.ResponseInputItem[],
+      messages: this.buildMessages(props.systemPrompt, props.messages),
     });
-
-    return response.output_text ?? '';
+    return this.firstContent(response);
   };
 
   public readonly rankByRelevance = async (
     concept: string,
     items: string[],
   ): Promise<number[]> => {
-    const response = await this.props.client.responses.create({
+    const response = await this.props.client.chat.completions.create({
       model: this.props.model,
       temperature: 0,
-      input: [
+      messages: [
         {
-          role: 'system' as const,
+          role: 'system',
           content: `You rank items by how much each one advances the given concept. Return every input index exactly once, ordered most to least relevant.
 Respond with ONLY a JSON object matching the schema.
 Example: {"rankedIndices": [2, 0, 1]}`,
         },
         {
-          role: 'user' as const,
+          role: 'user',
           content: `Concept:
 ${concept}
 
 Items:
 ${items.map((item, i) => `${i}: ${item}`).join('\n')}`,
         },
-      ] satisfies OpenAI.Responses.ResponseInputItem[],
-      text: {
-        format: {
-          type: 'json_schema',
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
           name: 'ranking',
+          strict: true,
           schema: {
             type: 'object',
             properties: {
@@ -82,42 +109,40 @@ ${items.map((item, i) => `${i}: ${item}`).join('\n')}`,
       },
     });
 
-    const { rankedIndices } = parseJsonOutput<{ rankedIndices: number[] }>(
-      response.output_text,
+    return parseJsonOutput<{ rankedIndices: number[] }>(
+      this.firstContent(response),
       'rankByRelevance',
-    );
-
-    return rankedIndices;
+    ).rankedIndices;
   };
 
   public readonly askYesNoQuestion = async (
     props: AskYesNoQuestionProps,
   ): Promise<boolean> => {
-    const response = await this.props.client.responses.create({
+    const response = await this.props.client.chat.completions.create({
       model: this.props.model,
       temperature: 0,
-      input: [
+      messages: [
+        { role: 'system', content: props.systemPrompt },
+        ...props.messages.map(
+          (m): ChatCompletionMessageParam => ({
+            role: 'user',
+            content: m.content,
+          }),
+        ),
         {
-          role: 'system' as const,
-          content: props.systemPrompt,
-        },
-        ...props.messages.map((m) => ({
-          role: 'user' as const,
-          content: m.content,
-        })),
-        {
-          role: 'user' as const,
+          role: 'user',
           content: `${props.question}
 
 Answer the above yes/no question.
 Respond with ONLY a JSON object matching the schema.
 Example: {"answer": true}`,
         },
-      ] satisfies OpenAI.Responses.ResponseInputItem[],
-      text: {
-        format: {
-          type: 'json_schema',
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
           name: 'yes_no_answer',
+          strict: true,
           schema: {
             type: 'object',
             properties: {
@@ -133,35 +158,35 @@ Example: {"answer": true}`,
       },
     });
 
-    const { answer } = parseJsonOutput<{ answer: boolean }>(
-      response.output_text,
+    return parseJsonOutput<{ answer: boolean }>(
+      this.firstContent(response),
       'askYesNoQuestion',
-    );
-    return answer;
+    ).answer;
   };
 
   public readonly splitString = async (
     content: string,
   ): Promise<[string, string]> => {
-    const response = await this.props.client.responses.create({
+    const response = await this.props.client.chat.completions.create({
       model: this.props.model,
       temperature: 0,
-      input: [
+      messages: [
         {
-          role: 'system' as const,
+          role: 'system',
           content: `A node's accumulated experience has grown too large and must split into two specialists. Divide the content by topic so each part is internally coherent and the two overlap as little as possible. Preserve the original wording; do not summarize or invent.
 Respond with ONLY a JSON object matching the schema.
 Example: {"left": "This is some content about rainbows.", "right": "This is some content about birds."}`,
         },
         {
-          role: 'user' as const,
+          role: 'user',
           content,
         },
-      ] satisfies OpenAI.Responses.ResponseInputItem[],
-      text: {
-        format: {
-          type: 'json_schema',
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
           name: 'split_output',
+          strict: true,
           schema: {
             type: 'object',
             properties: {
@@ -176,88 +201,72 @@ Example: {"left": "This is some content about rainbows.", "right": "This is some
     });
 
     const { left, right } = parseJsonOutput<{ left: string; right: string }>(
-      response.output_text,
+      this.firstContent(response),
       'splitString',
     );
 
     return [left, right];
   };
 
-  private mapToolToOpenAITool(tool: ToolDefinition): OpenAI.Responses.Tool {
+  private mapToolToOpenAITool(tool: ToolDefinition): ChatCompletionTool {
     return {
-      type: 'function' as const,
-      name: tool.name,
-      description: tool.description ?? null,
-      parameters: tool.parameters,
-      // Strict mode is only safe when the schema satisfies OpenAI's
-      // requirements (additionalProperties:false and all properties required,
-      // recursively). Enabling it on an arbitrary MCP schema gets the tool
-      // rejected, so we opt in only when the schema is provably compliant.
-      strict: isStrictEligible(tool.parameters),
+      type: 'function',
+      function: {
+        name: tool.name,
+        ...(tool.description !== undefined
+          ? { description: tool.description }
+          : {}),
+        parameters: tool.parameters,
+        // Strict mode is only safe when the schema satisfies OpenAI's
+        // requirements (additionalProperties:false and all properties required,
+        // recursively). Enabling it on an arbitrary MCP schema gets the tool
+        // rejected, so we opt in only when the schema is provably compliant.
+        strict: isStrictEligible(tool.parameters),
+      },
     };
   }
 
   public readonly generateWithTools = async (
     props: GenerateWithToolsProps,
   ): Promise<{ content: string; toolCalls: ToolCall[] | undefined }> => {
-    const inputItems: OpenAI.Responses.ResponseInputItem[] = [
-      {
-        role: 'system' as const,
-        content: props.systemPrompt,
-      } satisfies OpenAI.Responses.EasyInputMessage,
+    const messages: ChatCompletionMessageParam[] = [
+      { role: 'system', content: props.systemPrompt },
       ...props.messages.map(
-        (m) =>
-          ({
-            role: 'user',
-            content: m.content,
-          }) satisfies OpenAI.Responses.EasyInputMessage,
+        (m): ChatCompletionMessageParam => ({
+          role: 'user',
+          content: m.content,
+        }),
       ),
     ];
 
-    const mappedTools: OpenAI.Responses.Tool[] = [];
-    for (const tool of props.tools) {
-      mappedTools.push(this.mapToolToOpenAITool(tool));
-    }
+    const tools = props.tools.map((tool) => this.mapToolToOpenAITool(tool));
 
-    const params: {
-      model: string;
-      input: OpenAI.Responses.ResponseInputItem[];
-      tools: OpenAI.Responses.Tool[];
-    } = {
+    const response = await this.props.client.chat.completions.create({
       model: this.props.model,
-      input: inputItems,
-      tools: mappedTools,
-    };
-    const response = await this.props.client.responses.create({
-      ...params,
+      messages,
+      tools,
       tool_choice: 'required',
     });
-    const content = response.output_text ?? '';
+
+    const message = response.choices[0]?.message;
+    const content = message?.content ?? '';
     const toolCalls: ToolCall[] = [];
-    if (response.output && Array.isArray(response.output)) {
-      for (const item of response.output) {
-        if (
-          item &&
-          typeof item === 'object' &&
-          'type' in item &&
-          item.type === 'function_call'
-        ) {
-          const call = item as OpenAI.Responses.ResponseFunctionToolCall;
-          toolCalls.push({
-            id: call.call_id,
-            type: 'function' as const,
-            function: {
-              // `call.arguments` is already a JSON string per the Responses
-              // API. Re-stringifying double-encodes it, so the downstream
-              // JSON.parse in MCPClient.invokeTool yields a string instead of
-              // the arguments object and the tool call is malformed.
-              name: call.name,
-              arguments: call.arguments,
-            },
-          });
-        }
+    for (const call of message?.tool_calls ?? []) {
+      if (call.type === 'function') {
+        toolCalls.push({
+          id: call.id,
+          type: 'function',
+          // `call.function.arguments` is already a JSON string; pass it through
+          // unchanged so MCPClient.invokeTool parses the arguments object
+          // rather than a double-encoded string.
+          function: {
+            name: call.function.name,
+            arguments: call.function.arguments,
+          },
+        });
       }
     }
+
     if (toolCalls.length > 0) {
       return { content, toolCalls };
     }
@@ -266,16 +275,13 @@ Example: {"left": "This is some content about rainbows.", "right": "This is some
 }
 
 /**
- * Parses a structured-output response body, tolerating a missing/empty
- * `output_text` (which a local model can return on a refusal or tool-only
- * response) and markdown code fences, and surfacing failures with the calling
- * method's name rather than an opaque JSON error.
+ * Parses a structured-output response body, tolerating a missing/empty body
+ * (which a local model can return on a refusal or tool-only response) and
+ * markdown code fences, and surfacing failures with the calling method's name
+ * rather than an opaque JSON error.
  */
-const parseJsonOutput = <T>(
-  outputText: string | undefined,
-  method: string,
-): T => {
-  const cleaned = (outputText ?? '')
+const parseJsonOutput = <T>(content: string, method: string): T => {
+  const cleaned = content
     .replaceAll('```json', '')
     .replaceAll('```', '')
     .trim();

--- a/src/tui/app.test.tsx
+++ b/src/tui/app.test.tsx
@@ -1,0 +1,674 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import { App } from './app.js';
+import { ConcreteEventStream } from '../service/concrete-event-stream.js';
+import type { EpochOrchestrator } from '../orchestration/epoch-orchestrator.js';
+import type { Node } from '../types/node.js';
+
+const ESC = '\x1B';
+const BACKSPACE = '\x7F';
+const ENTER = '\r';
+
+const memoryNode = (id: string): Node<'memory'> => ({
+  id,
+  kind: 'memory',
+  status: 'idle',
+  context: '',
+  sendMessage: vi.fn(),
+});
+
+interface FakeOrchestrator {
+  nodes: Node<string>[];
+  workingMemory: { messages: { content: string }[] };
+  currentBroadcast: { content: string };
+  runEpoch: ReturnType<typeof vi.fn>;
+  injectBroadcast: ReturnType<typeof vi.fn>;
+}
+
+const makeOrchestrator = (
+  overrides: Partial<FakeOrchestrator> = {},
+): FakeOrchestrator => ({
+  nodes: [],
+  workingMemory: { messages: [] },
+  currentBroadcast: { content: '' },
+  runEpoch: vi.fn().mockResolvedValue(undefined),
+  injectBroadcast: vi.fn(),
+  ...overrides,
+});
+
+const asOrchestrator = (o: FakeOrchestrator): EpochOrchestrator =>
+  o as unknown as EpochOrchestrator;
+
+/** Let ink process input and re-render (real timers, short waits). */
+const tick = async (ms = 60): Promise<void> => {
+  await new Promise((r) => setTimeout(r, ms));
+};
+
+/**
+ * Poll `read()` until `predicate` holds, or fail after a timeout. Robust to the
+ * variable render latency of Ink (especially under coverage instrumentation),
+ * where a fixed sleep is flaky.
+ */
+const waitForFrame = async (
+  read: () => string | undefined,
+  predicate: (frame: string) => boolean,
+  timeoutMs = 2000,
+): Promise<string> => {
+  const start = Date.now();
+  for (;;) {
+    const frame = read() ?? '';
+    if (predicate(frame)) {
+      return frame;
+    }
+    if (Date.now() - start > timeoutMs) {
+      return frame;
+    }
+    await new Promise((r) => setTimeout(r, 15));
+  }
+};
+
+describe('App', () => {
+  let eventStream: ConcreteEventStream;
+
+  beforeEach(() => {
+    eventStream = new ConcreteEventStream();
+  });
+
+  it('renders the awaiting-broadcast state with seeded nodes and memory', () => {
+    const orchestrator = makeOrchestrator({
+      nodes: [memoryNode('seed-node-1')],
+      workingMemory: { messages: [{ content: 'remembered thing' }] },
+      currentBroadcast: { content: 'seed broadcast' },
+    });
+
+    const { lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    const out = lastFrame() ?? '';
+    expect(out).toContain('LEGION');
+    expect(out).toContain('AWAITING FIRST BROADCAST');
+    expect(out).toContain('seed-node-1');
+    expect(out).toContain('remembered thing');
+  });
+
+  it('injects a broadcast: [i] then type then [enter] starts the epoch loop', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+        epochDelayMs={10}
+      />,
+    );
+
+    stdin.write('i'); // enter input mode
+    await tick();
+    expect(lastFrame() ?? '').toContain('broadcast›');
+
+    stdin.write('hello'); // type
+    await tick();
+    stdin.write(ENTER); // enter
+    await tick();
+
+    expect(orchestrator.injectBroadcast).toHaveBeenCalledWith('hello');
+
+    // The loop is now started; after the epoch delay an epoch runs.
+    await waitForFrame(
+      lastFrame,
+      () => orchestrator.runEpoch.mock.calls.length > 0,
+    );
+    expect(orchestrator.runEpoch).toHaveBeenCalled();
+  });
+
+  it('injecting again after the loop has started does not re-log the start banner', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+        epochDelayMs={1000}
+      />,
+    );
+
+    // First injection starts the loop.
+    stdin.write('i');
+    await tick();
+    stdin.write('one');
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+
+    // Second injection while already started (exercises the started===true arm).
+    stdin.write('i');
+    await tick();
+    stdin.write('two');
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+
+    expect(orchestrator.injectBroadcast).toHaveBeenLastCalledWith('two');
+    // The "starting epochs" banner is only logged on the first start.
+    const out = lastFrame() ?? '';
+    const starts = out.split('starting epochs').length - 1;
+    expect(starts).toBeLessThanOrEqual(1);
+  });
+
+  it('ignores arrow keys while typing a broadcast', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    stdin.write('i');
+    await tick();
+    stdin.write('ab');
+    await tick();
+    stdin.write('\x1B[A'); // up arrow — must not append to the buffer
+    await tick();
+    stdin.write('\x1B[C'); // right arrow
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+
+    // Arrows were ignored, so only 'ab' was injected.
+    expect(orchestrator.injectBroadcast).toHaveBeenCalledWith('ab');
+  });
+
+  it('cancels input mode on [esc] without injecting', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    stdin.write('i');
+    await tick();
+    stdin.write('abc');
+    await tick();
+    stdin.write(ESC);
+    await tick();
+
+    expect(orchestrator.injectBroadcast).not.toHaveBeenCalled();
+    expect(lastFrame() ?? '').not.toContain('broadcast›');
+  });
+
+  it('supports backspace while typing a broadcast', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    stdin.write('i');
+    await tick();
+    stdin.write('hi');
+    await tick();
+    stdin.write(BACKSPACE);
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+
+    expect(orchestrator.injectBroadcast).toHaveBeenCalledWith('h');
+  });
+
+  it('ignores an empty broadcast submission', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    stdin.write('i');
+    await tick();
+    stdin.write(ENTER); // submit nothing
+    await tick();
+
+    expect(orchestrator.injectBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('toggles the expanded working-memory view with [m]', async () => {
+    const orchestrator = makeOrchestrator({
+      // Multiple entries exercise both the newest and older render arms in the
+      // compact (initial) and expanded panels.
+      workingMemory: {
+        messages: [
+          { content: 'older mem entry' },
+          { content: 'newest mem entry' },
+        ],
+      },
+    });
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    stdin.write('m');
+    // Expanded view shows the full-width memory panel header.
+    expect(
+      await waitForFrame(lastFrame, (f) => f.includes('oldest → newest')),
+    ).toContain('oldest → newest');
+
+    stdin.write('m');
+    // Collapsed view restores the side-by-side processors panel; the expanded
+    // header is gone.
+    const collapsed = await waitForFrame(
+      lastFrame,
+      (f) => !f.includes('oldest → newest'),
+    );
+    expect(collapsed).not.toContain('oldest → newest');
+    expect(collapsed).toContain('UNCONSCIOUS PROCESSORS');
+  });
+
+  it('pauses and resumes with [space]', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    // Start the loop first.
+    stdin.write('i');
+    await tick();
+    stdin.write('go');
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+
+    stdin.write(' '); // pause
+    expect(
+      await waitForFrame(lastFrame, (f) => f.includes('PAUSED')),
+    ).toContain('PAUSED');
+
+    stdin.write(' '); // resume
+    expect(
+      await waitForFrame(lastFrame, (f) => f.includes('RUNNING')),
+    ).toContain('RUNNING');
+  });
+
+  it('also pauses with the [p] alias and shows the active phase description', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    // A status change advances the phase pipeline, rendering a phase desc line.
+    eventStream.publish({
+      topicName: 'orchestrator/nodes-changed',
+      data: { allNodes: [memoryNode('n')] },
+    });
+    eventStream.publish({
+      topicName: 'node/status-change',
+      data: { nodeId: 'n', status: 'generating' },
+    });
+    expect(
+      await waitForFrame(lastFrame, (f) => f.includes('↳ processors generate')),
+    ).toContain('↳ processors generate');
+
+    // Start, then pause via the 'p' alias.
+    stdin.write('i');
+    await tick();
+    stdin.write('go');
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    // An unhandled command-mode key is a no-op (false arm of the pause check).
+    stdin.write('z');
+    await tick();
+    stdin.write('p');
+    expect(
+      await waitForFrame(lastFrame, (f) => f.includes('PAUSED')),
+    ).toContain('PAUSED');
+  });
+
+  it('quits with [q], calling onExit', async () => {
+    const orchestrator = makeOrchestrator();
+    const onExit = vi.fn();
+    const { stdin } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={onExit}
+      />,
+    );
+
+    stdin.write('q');
+    await tick();
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  it('also quits on ctrl+c', async () => {
+    const orchestrator = makeOrchestrator();
+    const onExit = vi.fn();
+    const { stdin } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={onExit}
+      />,
+    );
+
+    stdin.write('\x03'); // ctrl+c
+    await tick();
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  it('truncates long node ids in the processor list', async () => {
+    const orchestrator = makeOrchestrator({
+      nodes: [memoryNode('a-very-long-node-identifier-1234567890')],
+    });
+    const { lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    const out = lastFrame() ?? '';
+    expect(out).toContain('a-very-long-node');
+    expect(out).not.toContain('a-very-long-node-identifier-1234567890');
+  });
+
+  it('shows (empty) in the expanded memory view when there is no memory', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    stdin.write('m');
+    const out = await waitForFrame(lastFrame, (f) =>
+      f.includes('oldest → newest'),
+    );
+    expect(out).toContain('(empty)');
+  });
+
+  it('caps the activity log and keeps the most recent entries', async () => {
+    const orchestrator = makeOrchestrator();
+    const { lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    // Each node-added publish appends a log line; exceed the 100-line cap.
+    for (let i = 0; i < 120; i++) {
+      eventStream.publish({
+        topicName: 'orchestrator/node-added',
+        data: { addedNodes: [memoryNode(`spawned-${i}`)] },
+      });
+    }
+
+    const out = await waitForFrame(lastFrame, (f) => f.includes('spawned-119'));
+    // The newest entry is shown; the oldest has scrolled past the cap.
+    expect(out).toContain('spawned-119');
+    expect(out).not.toContain('spawned-0 ');
+  });
+
+  it('reflects orchestrator events in the view', async () => {
+    const orchestrator = makeOrchestrator();
+    const { lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    eventStream.publish({
+      topicName: 'orchestrator/nodes-changed',
+      data: { allNodes: [memoryNode('live-node')] },
+    });
+    eventStream.publish({
+      topicName: 'orchestrator/node-added',
+      data: { addedNodes: [memoryNode('live-node')] },
+    });
+    eventStream.publish({
+      topicName: 'node/status-change',
+      data: { nodeId: 'live-node', status: 'generating' },
+    });
+    eventStream.publish({
+      topicName: 'orchestrator/working-memory-updated',
+      data: {
+        workingMemory: { messages: [{ content: 'distilled mem' }] },
+        broadcast: { content: 'new broadcast' },
+      },
+    });
+    const out = await waitForFrame(
+      lastFrame,
+      // The distillation event writes a full-width activity-log line (the
+      // compact memory panel truncates, so assert on the log instead).
+      (f) => f.includes('live-node') && f.includes('distilled new broadcast'),
+    );
+    expect(out).toContain('live-node');
+    expect(out).toContain('distilled new broadcast');
+  });
+
+  it('keeps the consolidate phase when a generating status arrives mid-consolidation', async () => {
+    const orchestrator = makeOrchestrator();
+    const { lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    eventStream.publish({
+      topicName: 'orchestrator/nodes-changed',
+      data: { allNodes: [memoryNode('n')] },
+    });
+    // Enter the consolidate phase.
+    eventStream.publish({
+      topicName: 'orchestrator/working-memory-updated',
+      data: {
+        workingMemory: { messages: [{ content: 'm' }] },
+        broadcast: { content: 'b' },
+      },
+    });
+    await waitForFrame(lastFrame, (f) => f.includes('Consolidate'));
+    // A late generating status must NOT knock us back to the compete phase.
+    eventStream.publish({
+      topicName: 'node/status-change',
+      data: { nodeId: 'n', status: 'generating' },
+    });
+    const out = await waitForFrame(lastFrame, (f) =>
+      f.includes('distill → working memory'),
+    );
+    expect(out).toContain('distill → working memory');
+  });
+
+  it('logs a non-Error epoch rejection via String()', async () => {
+    const orchestrator = makeOrchestrator({
+      runEpoch: vi.fn().mockRejectedValue('plain string failure'),
+    });
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+        epochDelayMs={5}
+      />,
+    );
+
+    stdin.write('i');
+    await tick();
+    stdin.write('go');
+    await tick();
+    stdin.write(ENTER);
+
+    const out = await waitForFrame(lastFrame, (f) =>
+      f.includes('plain string failure'),
+    );
+    expect(out).toContain('plain string failure');
+  });
+
+  it('cancels a pending epoch when paused before the delay elapses', async () => {
+    const orchestrator = makeOrchestrator();
+    const { stdin } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+        epochDelayMs={1000}
+      />,
+    );
+
+    // Start the loop, then pause before the (long) epoch delay elapses so the
+    // effect cleanup cancels the scheduled epoch.
+    stdin.write('i');
+    await tick();
+    stdin.write('go');
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    stdin.write(' '); // pause -> cleanup clears the pending timer
+    await tick(40);
+
+    expect(orchestrator.runEpoch).not.toHaveBeenCalled();
+  });
+
+  it('skips a fired epoch whose effect was cancelled mid-flight', async () => {
+    // A runEpoch that blocks lets us flip `cancelled` (via pause) after the
+    // timer fires but before the async body resumes, exercising the in-body
+    // cancellation guard.
+    let releaseEpoch: (() => void) | undefined;
+    const orchestrator = makeOrchestrator({
+      runEpoch: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseEpoch = resolve;
+          }),
+      ),
+    });
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+        epochDelayMs={5}
+      />,
+    );
+
+    stdin.write('i');
+    await tick();
+    stdin.write('go');
+    await tick();
+    stdin.write(ENTER);
+
+    // Let the first epoch start and block inside runEpoch.
+    await waitForFrame(
+      lastFrame,
+      () => orchestrator.runEpoch.mock.calls.length > 0,
+    );
+    // Pause (cancels the in-flight effect), then let the blocked epoch resolve.
+    stdin.write(' ');
+    await tick();
+    releaseEpoch?.();
+    await tick(40);
+
+    // The epoch ran once; its completion was swallowed by the cancel guard, so
+    // no second epoch was scheduled.
+    expect(orchestrator.runEpoch).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs node removal and handles relevance/unknown status changes', async () => {
+    const orchestrator = makeOrchestrator();
+    const { lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+      />,
+    );
+
+    eventStream.publish({
+      topicName: 'orchestrator/nodes-changed',
+      data: { allNodes: [memoryNode('node-x')] },
+    });
+    // A status change for a node the view doesn't know about is ignored.
+    eventStream.publish({
+      topicName: 'node/status-change',
+      data: { nodeId: 'ghost', status: 'generating' },
+    });
+    // The relevance-evaluation status drives the attention phase.
+    eventStream.publish({
+      topicName: 'node/status-change',
+      data: { nodeId: 'node-x', status: 'evaluating-relevance' },
+    });
+    // An 'idle' status updates the node but matches no phase branch.
+    eventStream.publish({
+      topicName: 'node/status-change',
+      data: { nodeId: 'node-x', status: 'idle' },
+    });
+    // Removal writes a full-width activity-log line.
+    eventStream.publish({
+      topicName: 'orchestrator/node-removed',
+      data: { removedNodeIds: ['node-x'] },
+    });
+
+    const out = await waitForFrame(lastFrame, (f) =>
+      f.includes('pruned/split'),
+    );
+    expect(out).toContain('pruned/split');
+  });
+
+  it('logs an epoch error when runEpoch rejects', async () => {
+    const orchestrator = makeOrchestrator({
+      runEpoch: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+    const { stdin, lastFrame } = render(
+      <App
+        orchestrator={asOrchestrator(orchestrator)}
+        eventStream={eventStream}
+        onExit={() => {}}
+        epochDelayMs={5}
+      />,
+    );
+
+    stdin.write('i');
+    await tick();
+    stdin.write('start');
+    await tick();
+    stdin.write(ENTER);
+
+    const out = await waitForFrame(lastFrame, (f) => f.includes('error'));
+    expect(orchestrator.runEpoch).toHaveBeenCalled();
+    expect(out).toContain('error');
+  });
+});

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,0 +1,533 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text, useApp, useInput } from 'ink';
+import type { EventStream } from '../types/event-stream.js';
+import type { NodeStatus } from '../types/node.js';
+import type { EpochOrchestrator } from '../orchestration/epoch-orchestrator.js';
+import { Markdown, stripMarkdown } from './markdown.js';
+
+export interface AppProps {
+  readonly orchestrator: EpochOrchestrator;
+  readonly eventStream: EventStream;
+  /** Delay between epochs, in ms. */
+  readonly epochDelayMs?: number;
+  /** Called once the UI has exited so the caller can tear down. */
+  readonly onExit: () => void;
+}
+
+interface NodeView {
+  readonly id: string;
+  readonly kind: string;
+  readonly status: NodeStatus;
+}
+
+interface LogLine {
+  readonly id: number;
+  readonly text: string;
+  readonly color: string;
+}
+
+/** The Global Workspace Theory epoch cycle, as the user sees it unfold. */
+type Phase = 'idle' | 'broadcast' | 'compete' | 'attention' | 'consolidate';
+
+const PHASE_STEPS: ReadonlyArray<{
+  readonly phase: Exclude<Phase, 'idle'>;
+  readonly label: string;
+  readonly desc: string;
+}> = [
+  { phase: 'broadcast', label: 'Broadcast', desc: 'workspace → all processors' },
+  { phase: 'compete', label: 'Compete', desc: 'processors generate candidates' },
+  { phase: 'attention', label: 'Attention', desc: 'filter ranks by relevance' },
+  { phase: 'consolidate', label: 'Consolidate', desc: 'distill → working memory' },
+];
+
+const MAX_LOG_LINES = 100;
+const SPINNER = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+const STATUS_COLOR: Record<NodeStatus, string> = {
+  idle: 'gray',
+  generating: 'yellow',
+  'evaluating-relevance': 'cyan',
+};
+
+const STATUS_LABEL: Record<NodeStatus, string> = {
+  idle: 'idle',
+  generating: 'generating',
+  'evaluating-relevance': 'evaluating',
+};
+
+const shortId = (id: string): string => (id.length > 16 ? id.slice(0, 16) : id);
+
+export const App: React.FC<AppProps> = ({
+  orchestrator,
+  eventStream,
+  epochDelayMs = 750,
+  onExit,
+}) => {
+  const { exit } = useApp();
+  // Seed from the orchestrator so restored (persisted) nodes and working
+  // memory show immediately — the events that populate these fire during
+  // init(), before this component mounts and subscribes, so they'd be missed.
+  const [nodes, setNodes] = useState<Map<string, NodeView>>(
+    () =>
+      new Map(
+        orchestrator.nodes.map((node) => [
+          node.id,
+          { id: node.id, kind: node.kind, status: node.status },
+        ]),
+      ),
+  );
+  const [workingMemory, setWorkingMemory] = useState<string[]>(() =>
+    orchestrator.workingMemory.messages.map((m) => m.content),
+  );
+  const [broadcast, setBroadcast] = useState<string>(
+    orchestrator.currentBroadcast.content,
+  );
+  const [epoch, setEpoch] = useState<number>(0);
+  const [logs, setLogs] = useState<LogLine[]>([]);
+  const [paused, setPaused] = useState<boolean>(false);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [frame, setFrame] = useState<number>(0);
+  const [inputMode, setInputMode] = useState<boolean>(false);
+  const [inputValue, setInputValue] = useState<string>('');
+  // The epoch loop stays dormant until the first broadcast is injected.
+  const [started, setStarted] = useState<boolean>(false);
+  // Expanded, full-width, fully-readable working-memory view.
+  const [wmExpanded, setWmExpanded] = useState<boolean>(false);
+
+  const appendLog = (text: string, color = 'white'): void => {
+    setLogs((prev) => {
+      const next = [
+        ...prev,
+        { id: (prev[prev.length - 1]?.id ?? 0) + 1, text, color },
+      ];
+      return next.length > MAX_LOG_LINES
+        ? next.slice(next.length - MAX_LOG_LINES)
+        : next;
+    });
+  };
+
+  // Animation tick for the active-phase / generating spinner.
+  useEffect(() => {
+    const timer = setInterval(
+      () => setFrame((f) => (f + 1) % SPINNER.length),
+      110,
+    );
+    return () => clearInterval(timer);
+  }, []);
+
+  // Wire up event subscriptions once. Node statuses drive the phase pipeline.
+  useEffect(() => {
+    eventStream.subscribe({
+      topicName: 'orchestrator/nodes-changed',
+      receiver: ({ allNodes }) => {
+        setNodes((prev) => {
+          const next = new Map<string, NodeView>();
+          for (const node of allNodes) {
+            next.set(node.id, {
+              id: node.id,
+              kind: node.kind,
+              status: prev.get(node.id)?.status ?? node.status,
+            });
+          }
+          return next;
+        });
+      },
+    });
+
+    eventStream.subscribe({
+      topicName: 'orchestrator/node-added',
+      receiver: ({ addedNodes }) => {
+        for (const node of addedNodes) {
+          appendLog(`+ spawned ${shortId(node.id)} (${node.kind})`, 'green');
+        }
+      },
+    });
+
+    eventStream.subscribe({
+      topicName: 'orchestrator/node-removed',
+      receiver: ({ removedNodeIds }) => {
+        for (const id of removedNodeIds) {
+          appendLog(`- pruned/split ${shortId(id)}`, 'red');
+        }
+      },
+    });
+
+    eventStream.subscribe({
+      topicName: 'node/status-change',
+      receiver: ({ nodeId, status }) => {
+        setNodes((prev) => {
+          const existing = prev.get(nodeId);
+          if (!existing) return prev;
+          const next = new Map(prev);
+          next.set(nodeId, { ...existing, status });
+          return next;
+        });
+        if (status === 'generating') {
+          setPhase((p) => (p === 'consolidate' ? p : 'compete'));
+        } else if (status === 'evaluating-relevance') {
+          setPhase('attention');
+        }
+      },
+    });
+
+    eventStream.subscribe({
+      topicName: 'orchestrator/working-memory-updated',
+      receiver: ({ workingMemory: wm, broadcast: next }) => {
+        setWorkingMemory(wm.messages.map((m) => m.content));
+        setBroadcast(next.content);
+        setPhase('consolidate');
+        appendLog('✦ distilled new broadcast into working memory', 'magenta');
+      },
+    });
+  }, [eventStream]);
+
+  // Drive the epoch loop. Dormant until the first broadcast is injected.
+  useEffect(() => {
+    if (!started || paused) return;
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      if (cancelled) return;
+      setPhase('broadcast');
+      appendLog(`▶ epoch ${epoch}: broadcasting to all processors`, 'cyan');
+      try {
+        await orchestrator.runEpoch();
+        if (!cancelled) {
+          appendLog(`✓ epoch ${epoch} complete`, 'green');
+          setEpoch((n) => n + 1);
+        }
+      } catch (e) {
+        appendLog(
+          `✗ epoch ${epoch} error: ${e instanceof Error ? e.message : String(e)}`,
+          'red',
+        );
+        if (!cancelled) setEpoch((n) => n + 1);
+      }
+    }, epochDelayMs);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [epoch, paused, started, orchestrator, epochDelayMs]);
+
+  useInput((input, key) => {
+    // Input mode: capture typed text for an injected broadcast.
+    if (inputMode) {
+      if (key.return) {
+        const text = inputValue.trim();
+        if (text.length > 0) {
+          orchestrator.injectBroadcast(text);
+          appendLog(`☢ injected broadcast: ${text}`, 'magentaBright');
+          if (!started) {
+            setStarted(true);
+            appendLog('▶ first broadcast received — starting epochs', 'green');
+          }
+        }
+        setInputValue('');
+        setInputMode(false);
+        return;
+      }
+      if (key.escape) {
+        setInputValue('');
+        setInputMode(false);
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setInputValue((v) => v.slice(0, -1));
+        return;
+      }
+      // Append printable characters; ignore navigation / modifier keys.
+      if (
+        input.length > 0 &&
+        !key.ctrl &&
+        !key.meta &&
+        !key.tab &&
+        !key.upArrow &&
+        !key.downArrow &&
+        !key.leftArrow &&
+        !key.rightArrow
+      ) {
+        setInputValue((v) => v + input);
+      }
+      return;
+    }
+
+    // Command mode.
+    if (input === 'q' || (key.ctrl && input === 'c')) {
+      onExit();
+      exit();
+      return;
+    }
+    if (input === 'i') {
+      setInputMode(true);
+      return;
+    }
+    if (input === 'm') {
+      setWmExpanded((e) => !e);
+      return;
+    }
+    if (input === ' ' || input === 'p') {
+      setPaused((p) => !p);
+    }
+  });
+
+  const spin = SPINNER[frame] ?? SPINNER[0];
+  const nodeList = Array.from(nodes.values());
+  const competing = nodeList.filter((n) => n.status !== 'idle').length;
+  const activeStep = PHASE_STEPS.findIndex((s) => s.phase === phase);
+  const visibleLogs = logs.slice(-10);
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      {/* Title bar */}
+      <Box>
+        <Text bold color="magentaBright">
+          ◆ LEGION
+        </Text>
+        <Text color="gray"> Global Workspace Theory engine</Text>
+        <Text color="gray"> · epoch </Text>
+        <Text bold color="greenBright">
+          {epoch}
+        </Text>
+        <Text color="gray"> · </Text>
+        <Text
+          bold
+          color={
+            !started ? 'yellowBright' : paused ? 'redBright' : 'greenBright'
+          }
+        >
+          {!started
+            ? '◌ AWAITING FIRST BROADCAST'
+            : paused
+              ? '❚❚ PAUSED'
+              : `${spin} RUNNING`}
+        </Text>
+      </Box>
+
+      {/* GWT cycle pipeline */}
+      <Box
+        borderStyle="round"
+        borderColor="yellow"
+        flexDirection="column"
+        paddingX={1}
+        marginTop={1}
+      >
+        <Text bold color="yellow">
+          GWT EPOCH CYCLE
+        </Text>
+        <Box marginTop={1}>
+          {PHASE_STEPS.map((step, i) => {
+            const isActive = i === activeStep;
+            const isDone = activeStep >= 0 && i < activeStep;
+            const color = isActive
+              ? 'yellowBright'
+              : isDone
+                ? 'green'
+                : 'gray';
+            return (
+              <Box key={step.phase}>
+                <Text bold color={color}>
+                  {isActive ? spin : isDone ? '✓' : '○'} {i + 1}.{step.label}
+                </Text>
+                {i < PHASE_STEPS.length - 1 ? (
+                  <Text color="gray"> ──▶ </Text>
+                ) : null}
+              </Box>
+            );
+          })}
+        </Box>
+        <Text color="gray">
+          {activeStep >= 0
+            ? `↳ ${PHASE_STEPS[activeStep]?.desc ?? ''}`
+            : '↳ waiting for next epoch…'}
+        </Text>
+      </Box>
+
+      {/* Global workspace spotlight */}
+      <Box
+        borderStyle="double"
+        borderColor="magentaBright"
+        flexDirection="column"
+        paddingX={1}
+        marginTop={1}
+      >
+        <Text bold color="magentaBright">
+          ☀ GLOBAL WORKSPACE
+        </Text>
+        <Text color="gray">the single broadcast all processors receive</Text>
+        <Box marginTop={1}>
+          {started ? (
+            <Text color="whiteBright" wrap="truncate-end">
+              « {stripMarkdown(broadcast)} »
+            </Text>
+          ) : (
+            <Text color="yellow">
+              awaiting your first broadcast — press [i], type a message, then
+              [enter] to begin
+            </Text>
+          )}
+        </Box>
+      </Box>
+
+      {wmExpanded ? (
+        /* Expanded, full-width, fully-readable working memory */
+        <Box
+          borderStyle="round"
+          borderColor="blue"
+          flexDirection="column"
+          paddingX={1}
+          marginTop={1}
+        >
+          <Box>
+            <Text bold color="blue">
+              WORKING MEMORY{' '}
+            </Text>
+            <Text color="gray">
+              (rolling window · {workingMemory.length} entries · oldest → newest)
+            </Text>
+          </Box>
+          {workingMemory.length === 0 ? (
+            <Text color="gray">(empty)</Text>
+          ) : (
+            workingMemory.map((message, i) => {
+              const isNewest = i === workingMemory.length - 1;
+              return (
+                <Box key={i} flexDirection="column" marginTop={1}>
+                  <Text>
+                    <Text bold color={isNewest ? 'blueBright' : 'gray'}>
+                      #{i + 1}
+                    </Text>
+                    {isNewest ? (
+                      <Text bold color="greenBright">
+                        {'  '}◀ most recent
+                      </Text>
+                    ) : null}
+                  </Text>
+                  <Markdown
+                    text={message}
+                    color={isNewest ? 'whiteBright' : 'gray'}
+                  />
+                </Box>
+              );
+            })
+          )}
+        </Box>
+      ) : (
+        /* Dashboard: processors + compact working memory + activity */
+        <>
+          <Box marginTop={1}>
+            <Box
+              borderStyle="round"
+              borderColor="cyan"
+              flexDirection="column"
+              paddingX={1}
+              width="55%"
+            >
+              <Box>
+                <Text bold color="cyan">
+                  UNCONSCIOUS PROCESSORS{' '}
+                </Text>
+                <Text color="gray">({nodeList.length} nodes · </Text>
+                <Text color="yellowBright">{competing} active</Text>
+                <Text color="gray">)</Text>
+              </Box>
+              {nodeList.length === 0 ? (
+                <Text color="gray">(none yet — bootstrapping)</Text>
+              ) : (
+                nodeList.map((node) => {
+                  const glyph = node.status === 'idle' ? '○' : spin;
+                  return (
+                    <Box key={node.id}>
+                      <Text color={STATUS_COLOR[node.status]}>{glyph} </Text>
+                      <Text color="whiteBright">{shortId(node.id)} </Text>
+                      <Text color="gray">{node.kind} </Text>
+                      <Text color={STATUS_COLOR[node.status]}>
+                        {STATUS_LABEL[node.status]}
+                      </Text>
+                    </Box>
+                  );
+                })
+              )}
+            </Box>
+
+            <Box
+              borderStyle="round"
+              borderColor="blue"
+              flexDirection="column"
+              paddingX={1}
+              width="45%"
+            >
+              <Box>
+                <Text bold color="blue">
+                  WORKING MEMORY{' '}
+                </Text>
+                <Text color="gray">
+                  (rolling · {workingMemory.length} · [m] to expand)
+                </Text>
+              </Box>
+              {workingMemory.length === 0 ? (
+                <Text color="gray">(empty)</Text>
+              ) : (
+                workingMemory.slice(-7).map((message, i, shown) => {
+                  const isNewest = i === shown.length - 1;
+                  return (
+                    <Text
+                      key={i}
+                      wrap="truncate-end"
+                      color={isNewest ? 'whiteBright' : 'gray'}
+                    >
+                      {isNewest ? '▸ ' : '• '}
+                      {stripMarkdown(message)}
+                    </Text>
+                  );
+                })
+              )}
+            </Box>
+          </Box>
+
+          {/* Activity log */}
+          <Box
+            borderStyle="round"
+            borderColor="gray"
+            flexDirection="column"
+            paddingX={1}
+            marginTop={1}
+          >
+            <Text bold color="gray">
+              ACTIVITY
+            </Text>
+            {visibleLogs.length === 0 ? (
+              <Text color="gray">(waiting…)</Text>
+            ) : (
+              visibleLogs.map((line) => (
+                <Text key={line.id} color={line.color} wrap="truncate-end">
+                  {line.text}
+                </Text>
+              ))
+            )}
+          </Box>
+        </>
+      )}
+
+      <Box marginTop={1}>
+        {inputMode ? (
+          <Text>
+            <Text bold color="greenBright">
+              ☀ broadcast›{' '}
+            </Text>
+            <Text color="whiteBright">{inputValue}</Text>
+            <Text color="green">▏</Text>
+            <Text color="gray">
+              {'  '}[enter] send · [esc] cancel
+            </Text>
+          </Text>
+        ) : (
+          <Text color="gray">
+            [i] inject · [space] pause/resume ·{' '}
+            {wmExpanded ? '[m] collapse memory' : '[m] expand memory'} · [q]
+            quit
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -34,10 +34,22 @@ const PHASE_STEPS: ReadonlyArray<{
   readonly label: string;
   readonly desc: string;
 }> = [
-  { phase: 'broadcast', label: 'Broadcast', desc: 'workspace → all processors' },
-  { phase: 'compete', label: 'Compete', desc: 'processors generate candidates' },
+  {
+    phase: 'broadcast',
+    label: 'Broadcast',
+    desc: 'workspace → all processors',
+  },
+  {
+    phase: 'compete',
+    label: 'Compete',
+    desc: 'processors generate candidates',
+  },
   { phase: 'attention', label: 'Attention', desc: 'filter ranks by relevance' },
-  { phase: 'consolidate', label: 'Consolidate', desc: 'distill → working memory' },
+  {
+    phase: 'consolidate',
+    label: 'Consolidate',
+    desc: 'distill → working memory',
+  },
 ];
 
 const MAX_LOG_LINES = 100;
@@ -163,6 +175,7 @@ export const App: React.FC<AppProps> = ({
           return next;
         });
         if (status === 'generating') {
+          /* v8 ignore next -- the consolidate-preserving arm depends on React update ordering and can't be hit deterministically */
           setPhase((p) => (p === 'consolidate' ? p : 'compete'));
         } else if (status === 'evaluating-relevance') {
           setPhase('attention');
@@ -186,6 +199,9 @@ export const App: React.FC<AppProps> = ({
     if (!started || paused) return;
     let cancelled = false;
     const timer = setTimeout(async () => {
+      // Guards the race where the timer fires during effect teardown. The
+      // cleanup clears this timer, so the guard is effectively unreachable.
+      /* v8 ignore next 1 */
       if (cancelled) return;
       setPhase('broadcast');
       appendLog(`▶ epoch ${epoch}: broadcasting to all processors`, 'cyan');
@@ -200,6 +216,7 @@ export const App: React.FC<AppProps> = ({
           `✗ epoch ${epoch} error: ${e instanceof Error ? e.message : String(e)}`,
           'red',
         );
+        /* v8 ignore next -- post-cancel completion depends on async race timing */
         if (!cancelled) setEpoch((n) => n + 1);
       }
     }, epochDelayMs);
@@ -270,10 +287,13 @@ export const App: React.FC<AppProps> = ({
     }
   });
 
-  const spin = SPINNER[frame] ?? SPINNER[0];
+  // `frame` is kept in range by the animation effect, so this index is always
+  // defined (the assertion satisfies noUncheckedIndexedAccess without a branch).
+  const spin = SPINNER[frame]!;
   const nodeList = Array.from(nodes.values());
   const competing = nodeList.filter((n) => n.status !== 'idle').length;
   const activeStep = PHASE_STEPS.findIndex((s) => s.phase === phase);
+  const activeStepDesc = PHASE_STEPS.find((s) => s.phase === phase)?.desc ?? '';
   const visibleLogs = logs.slice(-10);
 
   return (
@@ -318,11 +338,7 @@ export const App: React.FC<AppProps> = ({
           {PHASE_STEPS.map((step, i) => {
             const isActive = i === activeStep;
             const isDone = activeStep >= 0 && i < activeStep;
-            const color = isActive
-              ? 'yellowBright'
-              : isDone
-                ? 'green'
-                : 'gray';
+            const color = isActive ? 'yellowBright' : isDone ? 'green' : 'gray';
             return (
               <Box key={step.phase}>
                 <Text bold color={color}>
@@ -337,7 +353,7 @@ export const App: React.FC<AppProps> = ({
         </Box>
         <Text color="gray">
           {activeStep >= 0
-            ? `↳ ${PHASE_STEPS[activeStep]?.desc ?? ''}`
+            ? `↳ ${activeStepDesc}`
             : '↳ waiting for next epoch…'}
         </Text>
       </Box>
@@ -382,7 +398,8 @@ export const App: React.FC<AppProps> = ({
               WORKING MEMORY{' '}
             </Text>
             <Text color="gray">
-              (rolling window · {workingMemory.length} entries · oldest → newest)
+              (rolling window · {workingMemory.length} entries · oldest →
+              newest)
             </Text>
           </Box>
           {workingMemory.length === 0 ? (
@@ -516,9 +533,7 @@ export const App: React.FC<AppProps> = ({
             </Text>
             <Text color="whiteBright">{inputValue}</Text>
             <Text color="green">▏</Text>
-            <Text color="gray">
-              {'  '}[enter] send · [esc] cancel
-            </Text>
+            <Text color="gray">{'  '}[enter] send · [esc] cancel</Text>
           </Text>
         ) : (
           <Text color="gray">

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,0 +1,46 @@
+import { render } from 'ink';
+import { init } from '../constants/initialization.js';
+import { App } from './app.js';
+
+const main = async (): Promise<void> => {
+  if (!process.stdin.isTTY) {
+    console.error(
+      'The Legion TUI needs an interactive terminal (TTY). Run it directly in your terminal.',
+    );
+    process.exit(1);
+  }
+
+  // attachConsoleLogging: false — keep the console subscribers off so they
+  // don't fight Ink for the screen. The TUI surfaces activity itself.
+  const { orchestrator, mcpClients, eventStream } = await init({
+    attachConsoleLogging: false,
+  });
+
+  let tornDown = false;
+  const teardown = async (): Promise<void> => {
+    if (tornDown) return;
+    tornDown = true;
+    await Promise.all(mcpClients.map((client) => client.close())).catch(
+      () => undefined,
+    );
+  };
+
+  const { waitUntilExit } = render(
+    <App
+      orchestrator={orchestrator}
+      eventStream={eventStream}
+      onExit={() => {
+        void teardown();
+      }}
+    />,
+  );
+
+  await waitUntilExit();
+  await teardown();
+  process.exit(0);
+};
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/tui/markdown.test.tsx
+++ b/src/tui/markdown.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { Markdown, stripMarkdown } from './markdown.js';
+
+const frameOf = (text: string): string => {
+  const { lastFrame } = render(<Markdown text={text} />);
+  return lastFrame() ?? '';
+};
+
+describe('Markdown', () => {
+  it('renders headings, paragraphs, and emphasis', () => {
+    const out = frameOf(
+      '# Title\n\nSome **bold** and *italic* and `code` text.',
+    );
+    expect(out).toContain('Title');
+    expect(out).toContain('bold');
+    expect(out).toContain('italic');
+    expect(out).toContain('code');
+  });
+
+  it('renders strikethrough, links, and a horizontal rule', () => {
+    const out = frameOf('~~gone~~ [label](https://example.com)\n\n---');
+    expect(out).toContain('gone');
+    expect(out).toContain('label');
+    expect(out).toContain('─');
+  });
+
+  it('renders fenced code blocks line by line', () => {
+    const out = frameOf('```\nline one\n\nline three\n```');
+    expect(out).toContain('line one');
+    expect(out).toContain('line three');
+  });
+
+  it('renders blockquotes with a gutter', () => {
+    const out = frameOf('> quoted text');
+    expect(out).toContain('quoted text');
+    expect(out).toContain('│');
+  });
+
+  it('renders ordered and nested unordered lists', () => {
+    const out = frameOf('1. first\n2. second\n   - nested');
+    expect(out).toContain('1.');
+    expect(out).toContain('2.');
+    expect(out).toContain('first');
+    expect(out).toContain('nested');
+    expect(out).toContain('•');
+  });
+
+  it('renders tables as labeled records', () => {
+    const out = frameOf('| Name | Role |\n| ---- | ---- |\n| Ada | Pioneer |');
+    expect(out).toContain('Name');
+    expect(out).toContain('Ada');
+    expect(out).toContain('Role');
+    expect(out).toContain('Pioneer');
+  });
+
+  it('renders inline line breaks and escapes', () => {
+    const out = frameOf('a\\*b line one  \nline two');
+    expect(out).toContain('line one');
+    expect(out).toContain('line two');
+  });
+
+  it('renders an explicit <br> as a line break', () => {
+    const out = frameOf('before<br>after');
+    expect(out).toContain('before');
+    expect(out).toContain('after');
+  });
+
+  it('accepts a custom base color without throwing', () => {
+    const { lastFrame } = render(<Markdown text="plain" color="green" />);
+    expect(lastFrame()).toContain('plain');
+  });
+
+  it('renders an inline token type without a dedicated case (image)', () => {
+    // An image is an inline token the switch does not special-case; it falls
+    // through to the default branch.
+    const { lastFrame } = render(
+      <Markdown text="![alt text](http://x/i.png)" />,
+    );
+    expect(lastFrame()).toContain('alt text');
+  });
+
+  it('renders a block token type without a dedicated case (raw HTML)', () => {
+    // A raw HTML block hits the block-level default branch.
+    const { lastFrame } = render(<Markdown text="<div>raw html block</div>" />);
+    expect(lastFrame()).toContain('raw html block');
+  });
+
+  it('renders an empty document without throwing', () => {
+    const { lastFrame } = render(<Markdown text="" />);
+    expect(lastFrame()).toBe('');
+  });
+
+  it('drops non-break inline HTML while keeping surrounding text', () => {
+    // Inline <span> is not <br>, so the html case returns null; the text around
+    // it still renders.
+    const { lastFrame } = render(
+      <Markdown text="before <span>x</span> after" />,
+    );
+    const out = lastFrame() ?? '';
+    expect(out).toContain('before');
+    expect(out).toContain('after');
+  });
+
+  it('renders a bare text paragraph (no nested inline tokens)', () => {
+    const { lastFrame } = render(<Markdown text="just plain words" />);
+    expect(lastFrame()).toContain('just plain words');
+  });
+
+  it('renders a loose list item containing block content', () => {
+    // A loose list (blank line between items) yields paragraph-wrapped item
+    // content, exercising nested block rendering inside list items.
+    const out = frameOf('- one\n\n- two\n');
+    expect(out).toContain('one');
+    expect(out).toContain('two');
+  });
+});
+
+describe('stripMarkdown', () => {
+  it('flattens formatting to plain text', () => {
+    expect(stripMarkdown('# Hi **there**')).toBe('Hi there');
+  });
+
+  it('collapses whitespace and trims', () => {
+    expect(stripMarkdown('a\n\n   b   c')).toBe('a b c');
+  });
+
+  it('replaces inline breaks/html with spaces', () => {
+    expect(stripMarkdown('one<br>two')).toContain('one');
+    expect(stripMarkdown('one<br>two')).toContain('two');
+  });
+
+  it('handles links and code spans', () => {
+    expect(stripMarkdown('see [docs](https://x.io) and `code`')).toContain(
+      'docs',
+    );
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stripMarkdown('')).toBe('');
+  });
+});

--- a/src/tui/markdown.tsx
+++ b/src/tui/markdown.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { marked, type Token, type Tokens } from 'marked';
+
+/**
+ * Markdown for the TUI: `marked` does the parsing (robust on nested emphasis,
+ * ordered/nested lists, fenced code, links, escapes), and we map its tokens to
+ * Ink primitives so layout/wrapping stays Ink-native. No ANSI string rendering.
+ */
+
+const HR = '─'.repeat(48);
+
+const renderInline = (
+  tokens: Token[] | undefined,
+  baseColor: string,
+): React.ReactNode[] => {
+  if (!tokens) {
+    return [];
+  }
+  return tokens.map((token, i) => {
+    switch (token.type) {
+      case 'strong':
+        return (
+          <Text key={i} bold color="whiteBright">
+            {renderInline(token.tokens, 'whiteBright')}
+          </Text>
+        );
+      case 'em':
+        return (
+          <Text key={i} italic color={baseColor}>
+            {renderInline(token.tokens, baseColor)}
+          </Text>
+        );
+      case 'del':
+        return (
+          <Text key={i} strikethrough color={baseColor}>
+            {renderInline(token.tokens, baseColor)}
+          </Text>
+        );
+      case 'codespan':
+        return (
+          <Text key={i} color="greenBright">
+            {token.text}
+          </Text>
+        );
+      case 'link':
+        return (
+          <Text key={i} underline color="blueBright">
+            {renderInline(token.tokens, 'blueBright')}
+          </Text>
+        );
+      case 'br':
+        return <Text key={i}>{'\n'}</Text>;
+      case 'html': {
+        // Inline HTML: turn <br> into a line break, drop other tags.
+        const raw = (token as Tokens.HTML).raw.trim();
+        return /^<br\s*\/?>$/i.test(raw) ? <Text key={i}>{'\n'}</Text> : null;
+      }
+      case 'escape':
+        return (
+          <Text key={i} color={baseColor}>
+            {token.text}
+          </Text>
+        );
+      case 'text':
+        return (
+          <Text key={i} color={baseColor}>
+            {token.tokens ? renderInline(token.tokens, baseColor) : token.text}
+          </Text>
+        );
+      default:
+        return (
+          <Text key={i} color={baseColor}>
+            {'text' in token ? (token.text as string) : ''}
+          </Text>
+        );
+    }
+  });
+};
+
+const renderBlocks = (
+  tokens: Token[],
+  baseColor: string,
+  depth = 0,
+): React.ReactNode[] => {
+  return tokens.map((token, i) => {
+    switch (token.type) {
+      case 'heading':
+        return (
+          <Text key={i} bold color="cyanBright" wrap="wrap">
+            {renderInline(token.tokens, 'cyanBright')}
+          </Text>
+        );
+      case 'paragraph':
+        return (
+          <Text key={i} color={baseColor} wrap="wrap">
+            {renderInline(token.tokens, baseColor)}
+          </Text>
+        );
+      case 'text':
+        return (
+          <Text key={i} color={baseColor} wrap="wrap">
+            {'tokens' in token && token.tokens
+              ? renderInline(token.tokens, baseColor)
+              : token.text}
+          </Text>
+        );
+      case 'space':
+        return <Text key={i}> </Text>;
+      case 'hr':
+        return (
+          <Text key={i} color="gray">
+            {HR}
+          </Text>
+        );
+      case 'code': {
+        const code = token as Tokens.Code;
+        return (
+          <Box key={i} flexDirection="column" paddingLeft={1}>
+            {code.text.split('\n').map((line, j) => (
+              <Text key={j} color="greenBright">
+                {line.length > 0 ? line : ' '}
+              </Text>
+            ))}
+          </Box>
+        );
+      }
+      case 'blockquote': {
+        const quote = token as Tokens.Blockquote;
+        return (
+          <Box key={i} flexDirection="column">
+            {renderBlocks(quote.tokens, 'gray', depth).map((node, j) => (
+              <Box key={j}>
+                <Text color="gray">│ </Text>
+                <Box flexDirection="column">{node}</Box>
+              </Box>
+            ))}
+          </Box>
+        );
+      }
+      case 'table': {
+        // Tables don't fit a narrow column as ASCII grids — render each row as
+        // a record: every cell labeled by its column header, content wrapped.
+        const table = token as Tokens.Table;
+        return (
+          <Box key={i} flexDirection="column">
+            {table.rows.map((row, r) => (
+              <Box key={r} flexDirection="column" marginTop={1}>
+                {row.map((cell, c) => (
+                  <Box key={c} flexDirection="column">
+                    <Text bold color="cyanBright" wrap="wrap">
+                      {table.header[c]?.text ?? ''}
+                    </Text>
+                    <Text color={baseColor} wrap="wrap">
+                      {renderInline(cell.tokens, baseColor)}
+                    </Text>
+                  </Box>
+                ))}
+              </Box>
+            ))}
+          </Box>
+        );
+      }
+      case 'list': {
+        const list = token as Tokens.List;
+        const start = typeof list.start === 'number' ? list.start : 1;
+        return (
+          <Box key={i} flexDirection="column" paddingLeft={depth > 0 ? 2 : 0}>
+            {list.items.map((item, j) => (
+              <Box key={j}>
+                <Text color={baseColor}>
+                  {list.ordered ? `${start + j}.` : '•'}{' '}
+                </Text>
+                <Box flexDirection="column">
+                  {renderBlocks(item.tokens, baseColor, depth + 1)}
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        );
+      }
+      default:
+        return (
+          <Text key={i} color={baseColor} wrap="wrap">
+            {token.raw}
+          </Text>
+        );
+    }
+  });
+};
+
+export interface MarkdownProps {
+  readonly text: string;
+  readonly color?: string;
+}
+
+export const Markdown: React.FC<MarkdownProps> = ({ text, color = 'gray' }) => {
+  return <>{renderBlocks(marked.lexer(text), color)}</>;
+};
+
+/**
+ * Plain-text projection for single-line truncated views — uses the same parser
+ * so it stays consistent with the rendered output.
+ */
+export const stripMarkdown = (text: string): string => {
+  const flatten = (tokens: Token[]): string =>
+    tokens
+      .map((token) => {
+        if (token.type === 'html' || token.type === 'br') {
+          return ' ';
+        }
+        if ('tokens' in token && token.tokens) {
+          return flatten(token.tokens);
+        }
+        if ('text' in token) {
+          return token.text as string;
+        }
+        return token.raw;
+      })
+      .join(' ');
+  return flatten(marked.lexer(text)).replace(/\s+/g, ' ').trim();
+};

--- a/src/tui/markdown.tsx
+++ b/src/tui/markdown.tsx
@@ -14,6 +14,7 @@ const renderInline = (
   tokens: Token[] | undefined,
   baseColor: string,
 ): React.ReactNode[] => {
+  /* v8 ignore next 3 -- defensive guard for an absent token list */
   if (!tokens) {
     return [];
   }
@@ -63,15 +64,23 @@ const renderInline = (
           </Text>
         );
       case 'text':
+        // Inline text tokens from `marked` carry no nested tokens.
         return (
           <Text key={i} color={baseColor}>
-            {token.tokens ? renderInline(token.tokens, baseColor) : token.text}
+            {token.text}
           </Text>
         );
+      case 'image':
+        return (
+          <Text key={i} color={baseColor}>
+            {token.text}
+          </Text>
+        );
+      /* v8 ignore next 7 -- catch-all for inline token types marked does not emit here */
       default:
         return (
           <Text key={i} color={baseColor}>
-            {'text' in token ? (token.text as string) : ''}
+            {token.raw}
           </Text>
         );
     }
@@ -98,11 +107,11 @@ const renderBlocks = (
           </Text>
         );
       case 'text':
+        // Block-level text tokens carry inline tokens; renderInline tolerates
+        // an absent list (see its guard), so no branch is needed here.
         return (
           <Text key={i} color={baseColor} wrap="wrap">
-            {'tokens' in token && token.tokens
-              ? renderInline(token.tokens, baseColor)
-              : token.text}
+            {renderInline(token.tokens, baseColor)}
           </Text>
         );
       case 'space':
@@ -146,13 +155,13 @@ const renderBlocks = (
           <Box key={i} flexDirection="column">
             {table.rows.map((row, r) => (
               <Box key={r} flexDirection="column" marginTop={1}>
-                {row.map((cell, c) => (
+                {table.header.map((headerCell, c) => (
                   <Box key={c} flexDirection="column">
                     <Text bold color="cyanBright" wrap="wrap">
-                      {table.header[c]?.text ?? ''}
+                      {headerCell.text}
                     </Text>
                     <Text color={baseColor} wrap="wrap">
-                      {renderInline(cell.tokens, baseColor)}
+                      {renderInline(row[c]?.tokens, baseColor)}
                     </Text>
                   </Box>
                 ))}

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -1,9 +1,9 @@
 import { Message } from './message.js';
 import { GenerateWithToolsProps, ToolCall, ToolDefinition } from './tool.js';
 import {
-  Response,
-  ResponseCreateParamsNonStreaming,
-} from 'openai/resources/responses/responses';
+  ChatCompletion,
+  ChatCompletionCreateParamsNonStreaming,
+} from 'openai/resources/chat/completions';
 import { OpenAI } from 'openai';
 import RequestOptions = OpenAI.RequestOptions;
 
@@ -41,10 +41,12 @@ export interface Provider {
 }
 
 export interface MinimalOpenAi {
-  readonly responses: {
-    readonly create: (
-      body: ResponseCreateParamsNonStreaming,
-      options?: RequestOptions,
-    ) => Promise<Response>;
+  readonly chat: {
+    readonly completions: {
+      readonly create: (
+        body: ChatCompletionCreateParamsNonStreaming,
+        options?: RequestOptions,
+      ) => Promise<ChatCompletion>;
+    };
   };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,14 +4,21 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     exclude: ['src/**/*.fixture.ts'],
     coverage: {
       provider: 'v8',
       reportsDirectory: 'coverage',
       reporter: ['json', 'lcov', 'text', 'clover'],
-      include: ['src/**/*.ts'],
-      exclude: ['src/types/**/*.ts', 'src/index.ts', 'src/**/constants/*'],
+      include: ['src/**/*.ts', 'src/**/*.tsx'],
+      exclude: [
+        'src/types/**/*.ts',
+        'src/index.ts',
+        'src/**/constants/*',
+        // Entrypoint bootstrap: render()/TTY/process.exit, not unit-testable
+        // (analogous to the excluded src/index.ts).
+        'src/tui/index.tsx',
+      ],
       thresholds: {
         branches: 100,
         functions: 100,


### PR DESCRIPTION
- Add a real-time Ink TUI that visualizes the Global Workspace Theory epoch cycle: phase pipeline, the broadcast spotlight, processors with live status, working memory, and an activity log
- Inject broadcasts from the TUI; the epoch loop stays dormant until the first injection, and seeds its panels from restored session state
- Expandable, markdown-rendered working-memory view (marked parser + an Ink-native renderer; tables render as labeled records)
- Switch OpenaiProvider/QueuingOpenAi/MinimalOpenAi from the OpenAI Responses API to Chat Completions so LM Studio enforces json_schema structured outputs and real tool calls