### PR TITLE
fix: validate tool calls and MCP errors

### DIFF
--- a/src/adapter/mcp-client.test.ts
+++ b/src/adapter/mcp-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MCPClient } from './mcp-client.js';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { ErrorStream } from '../types/error-stream.js';
 
 // Mock the MCP SDK Client
 interface MockSdkClient {
@@ -15,7 +16,10 @@ interface MockSdkClient {
     name: string;
     arguments: Record<string, unknown>;
   }) => Promise<{
-    content?: Array<{ type: 'text'; text: string }>;
+    content?: Array<
+      | { type: 'text'; text: string }
+      | { type: 'image'; data: string; mimeType: string }
+    >;
     structuredContent?: unknown;
     isError?: boolean;
     toolResult?: unknown;
@@ -59,7 +63,11 @@ describe('MCPClient', () => {
     ]);
   });
 
-  it('should fall back to an empty-object schema for a non-object inputSchema', async () => {
+  it('should ignore tools with a non-object inputSchema', async () => {
+    const errorStream: ErrorStream = {
+      publish: vi.fn(),
+      subscribe: vi.fn(),
+    };
     vi.mocked(mockSdkClient.listTools).mockResolvedValue({
       tools: [
         // A misbehaving server returning a non-object schema.
@@ -71,10 +79,19 @@ describe('MCPClient', () => {
       ],
     });
 
-    const mcpClient = new MCPClient({ client: asMockClient(mockSdkClient) });
+    const mcpClient = new MCPClient({
+      client: asMockClient(mockSdkClient),
+      errorStream,
+    });
     const tools = await mcpClient.getAvailableTools();
 
-    expect(tools[0]?.parameters).toEqual({ type: 'object', properties: {} });
+    expect(tools).toEqual([]);
+    expect(errorStream.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'MCPClient',
+        message: 'Ignored tool bad_tool because its input schema is invalid.',
+      }),
+    );
   });
 
   it('should handle missing description in tools', async () => {
@@ -165,6 +182,37 @@ describe('MCPClient', () => {
     expect(mockSdkClient.callTool).not.toHaveBeenCalled();
   });
 
+  it('should reject non-object JSON arguments before calling MCP', async () => {
+    const errorStream: ErrorStream = {
+      publish: vi.fn(),
+      subscribe: vi.fn(),
+    };
+    const mcpClient = new MCPClient({
+      client: asMockClient(mockSdkClient),
+      errorStream,
+    });
+
+    const result = await mcpClient.invokeTool(
+      'call_1',
+      'test_tool',
+      '"double-encoded"',
+    );
+
+    expect(result).toEqual({
+      callId: 'call_1',
+      name: 'test_tool',
+      success: false,
+      error: 'Tool arguments must be a JSON object.',
+    });
+    expect(mockSdkClient.callTool).not.toHaveBeenCalled();
+    expect(errorStream.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'MCPClient',
+        message: 'Tool test_tool received non-object arguments.',
+      }),
+    );
+  });
+
   it('should handle structuredContent in tool response', async () => {
     vi.mocked(mockSdkClient.callTool).mockResolvedValue({
       structuredContent: { value: 42, status: 'ok' },
@@ -190,6 +238,66 @@ describe('MCPClient', () => {
     const result = await mcpClient.invokeTool('call_1', 'test_tool', '{}');
 
     expect(result.result).toEqual({ toolResult: { data: 'result' } });
+  });
+
+  it('should return MCP isError responses as failures', async () => {
+    const errorStream: ErrorStream = {
+      publish: vi.fn(),
+      subscribe: vi.fn(),
+    };
+    vi.mocked(mockSdkClient.callTool).mockResolvedValue({
+      isError: true,
+      content: [
+        { type: 'text', text: 'Permission denied' },
+        { type: 'image', data: 'base64', mimeType: 'image/png' },
+        { type: 'text', text: 'Try a different account' },
+      ],
+    });
+    const mcpClient = new MCPClient({
+      client: asMockClient(mockSdkClient),
+      errorStream,
+    });
+
+    const result = await mcpClient.invokeTool('call_1', 'test_tool', '{}');
+
+    expect(result).toEqual({
+      callId: 'call_1',
+      name: 'test_tool',
+      success: false,
+      error: 'Permission denied\nTry a different account',
+    });
+    expect(errorStream.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'MCPClient',
+        message: 'Tool test_tool returned an MCP error result.',
+      }),
+    );
+  });
+
+  it('should describe an MCP isError response without text content', async () => {
+    vi.mocked(mockSdkClient.callTool).mockResolvedValue({
+      isError: true,
+      structuredContent: { code: 'FAILED' },
+    });
+    const mcpClient = new MCPClient({ client: asMockClient(mockSdkClient) });
+
+    const result = await mcpClient.invokeTool('call_1', 'test_tool', '{}');
+
+    expect(result.error).toBe(
+      'MCP tool test_tool returned an error: {"code":"FAILED"}',
+    );
+  });
+
+  it('should ignore non-text MCP error content when describing a failure', async () => {
+    vi.mocked(mockSdkClient.callTool).mockResolvedValue({
+      isError: true,
+      content: [{ type: 'image', data: 'base64', mimeType: 'image/png' }],
+    });
+    const mcpClient = new MCPClient({ client: asMockClient(mockSdkClient) });
+
+    const result = await mcpClient.invokeTool('call_1', 'test_tool', '{}');
+
+    expect(result.error).toBe('MCP tool test_tool returned isError: true.');
   });
 
   it('should handle error from MCP SDK callTool', async () => {

--- a/src/adapter/mcp-client.ts
+++ b/src/adapter/mcp-client.ts
@@ -1,6 +1,8 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { ToolDefinition } from '../types/tool.js';
 import { ErrorStream } from '../types/error-stream.js';
+import { isDefined, isRecord } from '../utilities/type-guards.js';
+import { createToolOutputPreview } from '../utilities/tool-output-preview.js';
 
 export interface ToolResult {
   readonly callId: string;
@@ -11,19 +13,16 @@ export interface ToolResult {
 }
 
 /**
- * Coerces an MCP tool's `inputSchema` into a usable JSON object schema.
+ * Accepts only usable JSON object schemas advertised by an MCP server.
  *
  * The MCP SDK types `inputSchema` loosely, and a misbehaving server can return
- * a non-object value. Rather than blindly casting and forwarding malformed
- * schemas to the model, fall back to a minimal empty-object schema (a tool
- * that takes no arguments) when the schema is not a usable object.
+ * a non-object value. Such a tool must not be offered to the model because no
+ * trustworthy argument-validation boundary can be established for it.
  */
-const normalizeToolSchema = (schema: unknown): Record<string, unknown> => {
-  if (typeof schema === 'object' && schema !== null && !Array.isArray(schema)) {
-    return schema as Record<string, unknown>;
-  }
-  return { type: 'object', properties: {} };
-};
+const normalizeToolSchema = (
+  schema: unknown,
+): Record<string, unknown> | undefined =>
+  isRecord(schema) ? schema : undefined;
 
 export class MCPClient {
   private readonly _client: Client;
@@ -40,11 +39,25 @@ export class MCPClient {
 
   public readonly getAvailableTools = async (): Promise<ToolDefinition[]> => {
     const response = await this._client.listTools();
-    return response.tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description ?? '',
-      parameters: normalizeToolSchema(tool.inputSchema),
-    }));
+    return response.tools.flatMap((tool) => {
+      const parameters = normalizeToolSchema(tool.inputSchema);
+      if (parameters === undefined) {
+        this._errorStream?.publish({
+          source: 'MCPClient',
+          message: `Ignored tool ${tool.name} because its input schema is invalid.`,
+          error: new Error('MCP tool input schema must be an object.'),
+          metadata: { name: tool.name },
+        });
+        return [];
+      }
+      return [
+        {
+          name: tool.name,
+          description: tool.description ?? '',
+          parameters,
+        },
+      ];
+    });
   };
 
   public readonly invokeTool = async (
@@ -52,9 +65,9 @@ export class MCPClient {
     name: string,
     argumentsStr: string,
   ): Promise<ToolResult> => {
-    let args: Record<string, unknown>;
+    let parsedArguments: unknown;
     try {
-      args = JSON.parse(argumentsStr);
+      parsedArguments = JSON.parse(argumentsStr) as unknown;
     } catch (error) {
       this._errorStream?.publish({
         source: 'MCPClient',
@@ -69,12 +82,43 @@ export class MCPClient {
         error: `Invalid arguments JSON: ${argumentsStr}`,
       };
     }
+    if (!isRecord(parsedArguments)) {
+      const error = new Error('Tool arguments must be a JSON object.');
+      this._errorStream?.publish({
+        source: 'MCPClient',
+        message: `Tool ${name} received non-object arguments.`,
+        error,
+        metadata: { callId, name },
+      });
+      return {
+        callId,
+        name,
+        success: false,
+        error: error.message,
+      };
+    }
 
     try {
       const result = await this._client.callTool({
         name,
-        arguments: args,
+        arguments: parsedArguments,
       });
+
+      if (result.isError === true) {
+        const errorMessage = semanticErrorMessage(name, result);
+        this._errorStream?.publish({
+          source: 'MCPClient',
+          message: `Tool ${name} returned an MCP error result.`,
+          error: new Error(errorMessage),
+          metadata: { callId, name },
+        });
+        return {
+          callId,
+          name,
+          success: false,
+          error: errorMessage,
+        };
+      }
 
       return {
         callId,
@@ -103,3 +147,31 @@ export class MCPClient {
     await this._client.close();
   };
 }
+
+const semanticErrorMessage = (
+  name: string,
+  result: Readonly<Record<string, unknown>>,
+): string => {
+  const content = result['content'];
+  if (Array.isArray(content)) {
+    const text = content
+      .map((item) =>
+        isRecord(item) &&
+        item['type'] === 'text' &&
+        typeof item['text'] === 'string'
+          ? item['text']
+          : undefined,
+      )
+      .filter(isDefined)
+      .join('\n')
+      .trim();
+    if (text.length > 0) {
+      return text;
+    }
+  }
+  const structuredContent = result['structuredContent'];
+  if (structuredContent !== undefined) {
+    return `MCP tool ${name} returned an error: ${createToolOutputPreview(structuredContent)}`;
+  }
+  return `MCP tool ${name} returned isError: true.`;
+};

--- a/src/constants/initialization.ts
+++ b/src/constants/initialization.ts
@@ -2,7 +2,7 @@ import rawSettings from '../../settings.js';
 import { OpenAI } from 'openai';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { isDefined } from '../utilities/is-defined.js';
+import { isDefined } from '../utilities/type-guards.js';
 import {
   LegionSettings,
   SensorProviderDefinition,

--- a/src/node/memory-node.ts
+++ b/src/node/memory-node.ts
@@ -13,7 +13,7 @@ import {
   formatActionRequests,
   formatMessagePayload,
 } from '../utilities/action-request.js';
-import { isDefined } from '../utilities/is-defined.js';
+import { isDefined } from '../utilities/type-guards.js';
 
 export interface MemoryNodeProps {
   readonly id: string;

--- a/src/node/tool-node.test.ts
+++ b/src/node/tool-node.test.ts
@@ -39,6 +39,7 @@ describe('ToolNode', () => {
     mockEventStream = {
       publish: vi.fn(),
       subscribe: vi.fn(),
+      reportError: vi.fn(),
     };
     mockMCPClient = {
       getAvailableTools: vi.fn().mockResolvedValue([]),
@@ -851,6 +852,547 @@ describe('ToolNode', () => {
         },
       ]),
     });
+  });
+
+  it('rejects an unadvertised targeted action before model or MCP invocation', async () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: 'search',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      },
+    ];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: {
+        role: 'broadcast',
+        content: 'Clear the active goal.',
+        actionRequests: [
+          {
+            id: 'request-clear',
+            targetNodeId: 'search-node',
+            operation: 'clear_active_goal',
+            arguments: { goalId: 'goal-1' },
+          },
+        ],
+      },
+    });
+
+    expect(mockProvider.generateWithTools).not.toHaveBeenCalled();
+    expect(mockRelevanceGate.isRelevant).not.toHaveBeenCalled();
+    expect(mockMCPClient.invokeTool).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      role: 'afferent',
+      originatingNodeId: 'search-node',
+      content: JSON.stringify([
+        {
+          callId: 'request-clear',
+          name: 'clear_active_goal',
+          success: false,
+          error:
+            'Tool clear_active_goal was not advertised by ToolNode search-node. Available tools: search.',
+        },
+      ]),
+    });
+    expect(mockEventStream.publish).toHaveBeenCalledWith({
+      topicName: 'tool/invocation-completed',
+      data: {
+        nodeId: 'search-node',
+        callId: 'request-clear',
+        toolName: 'clear_active_goal',
+        success: false,
+        output:
+          'Tool clear_active_goal was not advertised by ToolNode search-node. Available tools: search.',
+      },
+    });
+  });
+
+  it('rejects targeted action arguments that violate the advertised schema', async () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: 'search',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      },
+    ];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: {
+        role: 'broadcast',
+        content: 'Search.',
+        actionRequests: [
+          {
+            id: 'request-search',
+            targetNodeId: 'search-node',
+            operation: 'search',
+            arguments: {},
+          },
+        ],
+      },
+    });
+
+    expect(mockProvider.generateWithTools).not.toHaveBeenCalled();
+    expect(mockMCPClient.invokeTool).not.toHaveBeenCalled();
+    expect(result?.content).toContain(
+      'Tool search arguments do not match its advertised schema:',
+    );
+    expect(result?.content).toContain("must have required property 'query'");
+  });
+
+  it('continues valid targeted actions when another request is invalid', async () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: 'search',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      },
+    ];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    vi.mocked(mockMCPClient.invokeTool).mockResolvedValue({
+      callId: 'call-search',
+      name: 'search',
+      success: true,
+      result: { results: ['match'] },
+    });
+    vi.mocked(mockProvider.generateWithTools).mockResolvedValue({
+      content: '',
+      toolCalls: [
+        {
+          id: 'call-search',
+          type: 'function',
+          function: {
+            name: 'search',
+            arguments: JSON.stringify({ query: 'Legion' }),
+          },
+        },
+      ],
+    });
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: {
+        role: 'broadcast',
+        content: 'Clear the goal and search for Legion.',
+        actionRequests: [
+          {
+            id: 'request-clear',
+            targetNodeId: 'search-node',
+            operation: 'clear_active_goal',
+            arguments: { goalId: 'goal-1' },
+          },
+          {
+            id: 'request-search',
+            targetNodeId: 'search-node',
+            operation: 'search',
+            arguments: { query: 'Legion' },
+          },
+        ],
+      },
+    });
+
+    expect(mockProvider.generateWithTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            actionRequests: [expect.objectContaining({ id: 'request-search' })],
+          }),
+        ],
+      }),
+    );
+    expect(mockMCPClient.invokeTool).toHaveBeenCalledTimes(1);
+    expect(result?.content).toContain('request-clear');
+    expect(result?.content).toContain('call-search');
+  });
+
+  it.each([
+    { description: 'relevance rejects the valid request', relevant: false },
+    { description: 'the provider returns no call', relevant: true },
+  ])('preserves preflight failures when $description', async ({ relevant }) => {
+    const tools: ToolDefinition[] = [
+      { name: 'search', parameters: { type: 'object' } },
+    ];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    vi.mocked(mockRelevanceGate.isRelevant).mockResolvedValue(relevant);
+    vi.mocked(mockProvider.generateWithTools).mockResolvedValue({
+      content: '',
+      toolCalls: undefined,
+    });
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: {
+        role: 'broadcast',
+        content: 'Clear the goal and search.',
+        actionRequests: [
+          {
+            id: 'request-clear',
+            targetNodeId: 'search-node',
+            operation: 'clear_active_goal',
+            arguments: {},
+          },
+          {
+            id: 'request-search',
+            targetNodeId: 'search-node',
+            operation: 'search',
+            arguments: {},
+          },
+        ],
+      },
+    });
+
+    expect(result?.content).toContain('request-clear');
+    expect(mockMCPClient.invokeTool).not.toHaveBeenCalled();
+    expect(mockProvider.generateWithTools).toHaveBeenCalledTimes(
+      relevant ? 1 : 0,
+    );
+  });
+
+  it('rejects a provider-selected tool that was not offered', async () => {
+    const tools: ToolDefinition[] = [{ name: 'search', parameters: {} }];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    vi.mocked(mockProvider.generateWithTools).mockResolvedValue({
+      content: '',
+      toolCalls: [
+        {
+          id: 'call-unknown',
+          type: 'function',
+          function: { name: 'clear_active_goal', arguments: '{}' },
+        },
+      ],
+    });
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: { role: 'broadcast', content: 'Search.' },
+    });
+
+    expect(mockMCPClient.invokeTool).not.toHaveBeenCalled();
+    expect(result?.content).toContain(
+      'Tool clear_active_goal was not advertised by ToolNode search-node.',
+    );
+  });
+
+  it('rejects malformed provider arguments before MCP invocation', async () => {
+    const tools: ToolDefinition[] = [{ name: 'search', parameters: {} }];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    vi.mocked(mockProvider.generateWithTools).mockResolvedValue({
+      content: '',
+      toolCalls: [
+        {
+          id: 'call-malformed',
+          type: 'function',
+          function: { name: 'search', arguments: '{not-json' },
+        },
+      ],
+    });
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: { role: 'broadcast', content: 'Search.' },
+    });
+
+    expect(mockMCPClient.invokeTool).not.toHaveBeenCalled();
+    expect(result?.content).toContain(
+      'Tool search arguments are not valid JSON.',
+    );
+  });
+
+  it('rejects structurally malformed provider calls with completion events', async () => {
+    const tools: ToolDefinition[] = [{ name: 'search', parameters: {} }];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    vi.mocked(mockProvider.generateWithTools).mockResolvedValue({
+      content: '',
+      toolCalls: [
+        null,
+        {
+          id: 'call-bad-shape',
+          type: 'function',
+          function: { name: 'search', arguments: { query: 'Legion' } },
+        },
+        {
+          id: 'call-wrong-type',
+          type: 'custom',
+          function: { name: 'search', arguments: '{}' },
+        },
+      ] as unknown as import('../types/tool.js').ToolCall[],
+    });
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: { role: 'broadcast', content: 'Search.' },
+    });
+
+    expect(mockMCPClient.invokeTool).not.toHaveBeenCalled();
+    expect(result?.content).toContain(
+      'Provider returned a malformed tool call',
+    );
+    expect(result?.content).toContain('call-bad-shape');
+    expect(mockEventStream.publish).toHaveBeenCalledWith({
+      topicName: 'tool/invocation-completed',
+      data: expect.objectContaining({
+        callId: 'call-bad-shape',
+        toolName: 'search',
+        success: false,
+      }),
+    });
+  });
+
+  it('rejects provider arguments that are not JSON objects', async () => {
+    const tools: ToolDefinition[] = [{ name: 'search', parameters: {} }];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    vi.mocked(mockProvider.generateWithTools).mockResolvedValue({
+      content: '',
+      toolCalls: [
+        {
+          id: 'call-array',
+          type: 'function',
+          function: { name: 'search', arguments: '[]' },
+        },
+      ],
+    });
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: { role: 'broadcast', content: 'Search.' },
+    });
+
+    expect(mockMCPClient.invokeTool).not.toHaveBeenCalled();
+    expect(result?.content).toContain(
+      'Tool search arguments must be a JSON object.',
+    );
+  });
+
+  it('rejects provider arguments that violate the advertised schema', async () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: 'search',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
+    ];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    vi.mocked(mockProvider.generateWithTools).mockResolvedValue({
+      content: '',
+      toolCalls: [
+        {
+          id: 'call-invalid',
+          type: 'function',
+          function: {
+            name: 'search',
+            arguments: JSON.stringify({ query: 42 }),
+          },
+        },
+      ],
+    });
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: { role: 'broadcast', content: 'Search.' },
+    });
+
+    expect(mockMCPClient.invokeTool).not.toHaveBeenCalled();
+    expect(result?.content).toContain('data/query must be string');
+  });
+
+  it('fails closed when a tool advertises an invalid schema', async () => {
+    const tools: ToolDefinition[] = [
+      { name: 'search', parameters: { type: 'not-a-json-schema-type' } },
+    ];
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    vi.mocked(mockProvider.generateWithTools).mockResolvedValue({
+      content: '',
+      toolCalls: [
+        {
+          id: 'call-invalid-schema',
+          type: 'function',
+          function: { name: 'search', arguments: '{}' },
+        },
+      ],
+    });
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    const result = await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: { role: 'broadcast', content: 'Search.' },
+    });
+
+    expect(mockMCPClient.invokeTool).not.toHaveBeenCalled();
+    expect(result?.content).toContain(
+      'Tool search has an invalid advertised schema:',
+    );
+  });
+
+  it('bounds failure output in invocation-completed events', async () => {
+    const tools: ToolDefinition[] = [{ name: 'search', parameters: {} }];
+    const longError = `failure: ${'x'.repeat(400)}`;
+    vi.mocked(mockMCPClient.getAvailableTools).mockResolvedValue(tools);
+    vi.mocked(mockMCPClient.invokeTool).mockResolvedValue({
+      callId: 'call-long-error',
+      name: 'search',
+      success: false,
+      error: longError,
+    });
+    vi.mocked(mockProvider.generateWithTools).mockResolvedValue({
+      content: '',
+      toolCalls: [
+        {
+          id: 'call-long-error',
+          type: 'function',
+          function: { name: 'search', arguments: '{}' },
+        },
+      ],
+    });
+    const node = new ToolNode({
+      capabilityDescription: 'can search.',
+      id: 'search-node',
+      provider: mockProvider,
+      eventStream: mockEventStream,
+      mcpClient:
+        mockMCPClient as unknown as import('../adapter/mcp-client.js').MCPClient,
+      relevanceGate: mockRelevanceGate,
+    });
+    await node.initialize();
+
+    await node.sendMessage({
+      workingMemory: { messages: [] },
+      broadcast: { role: 'broadcast', content: 'Search.' },
+    });
+
+    const completion = vi
+      .mocked(mockEventStream.publish)
+      .mock.calls.map(([event]) => event)
+      .find(
+        (event) =>
+          event.topicName === 'tool/invocation-completed' &&
+          event.data.callId === 'call-long-error',
+      );
+    expect(completion).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ success: false }),
+      }),
+    );
+    if (completion?.topicName === 'tool/invocation-completed') {
+      expect(completion.data.output).toHaveLength(240);
+      expect(completion.data.output.endsWith('…')).toBe(true);
+    }
   });
 
   it('should handle multiple tool calls in parallel', async () => {

--- a/src/node/tool-node.ts
+++ b/src/node/tool-node.ts
@@ -11,6 +11,12 @@ import { MCPClient, ToolResult } from '../adapter/mcp-client.js';
 import { RelevanceGate } from '../types/relevance-gate.js';
 import { createToolOutputPreview } from '../utilities/tool-output-preview.js';
 import { Message } from '../types/message.js';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
+import {
+  hasDefinedProperty,
+  isRecord,
+  isToolCall,
+} from '../utilities/type-guards.js';
 
 export interface ToolNodeProps {
   readonly id: string;
@@ -56,15 +62,43 @@ export class ToolNode implements Node<'tool'> {
   public readonly sendMessage = async (
     broadcastMessage: BroadcastMessage,
   ): Promise<NodeResponse> => {
-    const { provider, mcpClient } = this.props;
+    const { provider } = this.props;
     if (this.tools.length === 0) {
       await this.initialize();
     }
-    // Expose only requests addressed to this node during generation. The
-    // relevance gate still receives the original broadcast for routing.
+    // Validate requests addressed to this node before model selection. Invalid
+    // requests become failures; valid requests continue independently.
     const targetedRequests = broadcastMessage.broadcast.actionRequests?.filter(
       (request) => request.targetNodeId === this.id,
     );
+    const targetedRequestValidations = (targetedRequests ?? []).map(
+      (request) => ({
+        request,
+        error: this.validateToolSelection(request.operation, request.arguments),
+      }),
+    );
+    const invalidTargetedRequests = targetedRequestValidations.filter(
+      hasDefinedProperty('error'),
+    );
+    const validTargetedRequests = targetedRequestValidations
+      .filter(({ error }) => error === undefined)
+      .map(({ request }) => request);
+    let preflightFailures: ToolResult[] = [];
+    if (invalidTargetedRequests.length > 0) {
+      this.setStatus('generating');
+      preflightFailures = invalidTargetedRequests.map(({ request, error }) =>
+        this.rejectToolCall(
+          request.id,
+          request.operation,
+          JSON.stringify(request.arguments),
+          error,
+        ),
+      );
+      this.setStatus('idle');
+      if (validTargetedRequests.length === 0) {
+        return this.toolResponse(preflightFailures);
+      }
+    }
     const broadcast: Message = {
       role: broadcastMessage.broadcast.role,
       content: broadcastMessage.broadcast.content,
@@ -78,9 +112,9 @@ export class ToolNode implements Node<'tool'> {
         : {
             contributingNodeIds: broadcastMessage.broadcast.contributingNodeIds,
           }),
-      ...(targetedRequests === undefined || targetedRequests.length === 0
+      ...(validTargetedRequests.length === 0
         ? {}
-        : { actionRequests: targetedRequests }),
+        : { actionRequests: validTargetedRequests }),
     };
     const messages = [...broadcastMessage.workingMemory.messages, broadcast];
     const nodeBroadcastMessage: BroadcastMessage = {
@@ -96,7 +130,9 @@ export class ToolNode implements Node<'tool'> {
     });
     if (!(await relevant)) {
       this.setStatus('idle');
-      return undefined;
+      return preflightFailures.length === 0
+        ? undefined
+        : this.toolResponse(preflightFailures);
     }
     this.setStatus('idle');
     this.setStatus('generating');
@@ -107,72 +143,172 @@ export class ToolNode implements Node<'tool'> {
     });
     if (!response.toolCalls || response.toolCalls.length === 0) {
       this.setStatus('idle');
-      return undefined;
+      return preflightFailures.length === 0
+        ? undefined
+        : this.toolResponse(preflightFailures);
     }
     const toolCallResponse = await Promise.all(
-      response.toolCalls.map(async (call) => {
-        this.props.eventStream.publish({
-          topicName: 'tool/invocation-started',
-          data: {
-            nodeId: this.id,
-            callId: call.id,
-            toolName: call.function.name,
-            arguments: call.function.arguments,
-          },
-        });
-        try {
-          const result = await mcpClient.invokeTool(
-            call.id,
-            call.function.name,
-            call.function.arguments,
-          );
-          this.props.eventStream.publish({
-            topicName: 'tool/invocation-completed',
-            data: {
-              nodeId: this.id,
-              callId: call.id,
-              toolName: call.function.name,
-              success: result.success,
-              output: createToolOutputPreview(
-                result.success ? result.result : result.error,
-              ),
-            },
-          });
-          return result;
-        } catch (e) {
-          this.props.eventStream.reportError?.({
-            source: `ToolNode ${this.id}`,
-            message: `Tool ${call.function.name} threw during invocation.`,
-            error: e,
-            metadata: { callId: call.id, toolName: call.function.name },
-          });
-          const failure = {
-            callId: call.id,
-            name: call.function.name,
-            success: false,
-            error: `${e}`,
-          } satisfies ToolResult;
-          this.props.eventStream.publish({
-            topicName: 'tool/invocation-completed',
-            data: {
-              nodeId: this.id,
-              callId: call.id,
-              toolName: call.function.name,
-              success: false,
-              output: createToolOutputPreview(`${e}`),
-            },
-          });
-          return failure;
-        }
-      }),
+      response.toolCalls.map((call) => this.invokeProviderToolCall(call)),
     );
     this.setStatus('idle');
-    return {
-      role: 'afferent',
-      originatingNodeId: this.id,
-      content: JSON.stringify(toolCallResponse),
-    };
+    return this.toolResponse([...preflightFailures, ...toolCallResponse]);
   };
+
+  private readonly invokeProviderToolCall = async (
+    call: unknown,
+  ): Promise<ToolResult> => {
+    if (!isToolCall(call)) {
+      const details = malformedToolCallDetails(call);
+      return this.rejectToolCall(
+        details.callId,
+        details.name,
+        details.arguments,
+        `Provider returned a malformed tool call: ${createToolOutputPreview(call)}`,
+      );
+    }
+    const { id: callId, function: functionCall } = call;
+    const { name, arguments: argumentsStr } = functionCall;
+    this.publishInvocationStarted(callId, name, argumentsStr);
+
+    let parsedArguments: unknown;
+    try {
+      parsedArguments = JSON.parse(argumentsStr) as unknown;
+    } catch {
+      return this.rejectStartedToolCall(
+        callId,
+        name,
+        `Tool ${name} arguments are not valid JSON.`,
+      );
+    }
+
+    const validationError = this.validateToolSelection(name, parsedArguments);
+    if (validationError !== undefined) {
+      return this.rejectStartedToolCall(callId, name, validationError);
+    }
+
+    try {
+      const result = await this.props.mcpClient.invokeTool(
+        callId,
+        name,
+        argumentsStr,
+      );
+      this.publishInvocationCompleted(
+        callId,
+        name,
+        result.success,
+        result.success ? result.result : result.error,
+      );
+      return result;
+    } catch (error) {
+      this.props.eventStream.reportError?.({
+        source: `ToolNode ${this.id}`,
+        message: `Tool ${name} threw during invocation.`,
+        error,
+        metadata: { callId, toolName: name },
+      });
+      const errorMessage = String(error);
+      this.publishInvocationCompleted(callId, name, false, errorMessage);
+      return {
+        callId,
+        name,
+        success: false,
+        error: errorMessage,
+      };
+    }
+  };
+
+  private readonly validateToolSelection = (
+    name: string,
+    argumentsValue: unknown,
+  ): string | undefined => {
+    const tool = this.tools.find((candidate) => candidate.name === name);
+    if (tool === undefined) {
+      const available = this.tools
+        .map((candidate) => candidate.name)
+        .join(', ');
+      return `Tool ${name} was not advertised by ToolNode ${this.id}. Available tools: ${available}.`;
+    }
+    if (!isRecord(argumentsValue)) {
+      return `Tool ${name} arguments must be a JSON object.`;
+    }
+    try {
+      const validation = new AjvJsonSchemaValidator().getValidator(
+        tool.parameters,
+      )(argumentsValue);
+      return validation.valid
+        ? undefined
+        : `Tool ${name} arguments do not match its advertised schema: ${validation.errorMessage}.`;
+    } catch (error) {
+      return `Tool ${name} has an invalid advertised schema: ${String(error)}.`;
+    }
+  };
+
+  private readonly rejectToolCall = (
+    callId: string,
+    name: string,
+    argumentsStr: string,
+    error: string,
+  ): ToolResult => {
+    this.publishInvocationStarted(callId, name, argumentsStr);
+    return this.rejectStartedToolCall(callId, name, error);
+  };
+
+  private readonly rejectStartedToolCall = (
+    callId: string,
+    name: string,
+    error: string,
+  ): ToolResult => {
+    this.props.eventStream.reportError?.({
+      source: `ToolNode ${this.id}`,
+      message: `Rejected tool ${name} before MCP invocation.`,
+      error: new Error(error),
+      metadata: { callId, toolName: name },
+    });
+    this.publishInvocationCompleted(callId, name, false, error);
+    return { callId, name, success: false, error };
+  };
+
+  private readonly publishInvocationStarted = (
+    callId: string,
+    toolName: string,
+    argumentsStr: string,
+  ): void => {
+    this.props.eventStream.publish({
+      topicName: 'tool/invocation-started',
+      data: {
+        nodeId: this.id,
+        callId,
+        toolName,
+        arguments: argumentsStr,
+      },
+    });
+  };
+
+  private readonly publishInvocationCompleted = (
+    callId: string,
+    toolName: string,
+    success: boolean,
+    output: unknown,
+  ): void => {
+    this.props.eventStream.publish({
+      topicName: 'tool/invocation-completed',
+      data: {
+        nodeId: this.id,
+        callId,
+        toolName,
+        success,
+        output: createToolOutputPreview(output),
+      },
+    });
+  };
+
+  private readonly toolResponse = (
+    results: readonly ToolResult[],
+  ): Exclude<NodeResponse, undefined> => ({
+    role: 'afferent',
+    originatingNodeId: this.id,
+    content: JSON.stringify(results),
+  });
 
   private readonly setStatus = (newStatus: NodeStatus): void => {
     this._nodeStatus = newStatus;
@@ -201,3 +337,30 @@ ${this.tools.map((tool) => JSON.stringify(tool)).join('\n')}
 `;
   }
 }
+
+const malformedToolCallDetails = (
+  call: unknown,
+): {
+  readonly callId: string;
+  readonly name: string;
+  readonly arguments: string;
+} => {
+  const callRecord = isRecord(call) ? call : {};
+  const functionCall = isRecord(callRecord['function'])
+    ? callRecord['function']
+    : {};
+  return {
+    callId:
+      typeof callRecord['id'] === 'string'
+        ? callRecord['id']
+        : '[missing-call-id]',
+    name:
+      typeof functionCall['name'] === 'string'
+        ? functionCall['name']
+        : '[missing-tool-name]',
+    arguments:
+      typeof functionCall['arguments'] === 'string'
+        ? functionCall['arguments']
+        : createToolOutputPreview(functionCall['arguments']),
+  };
+};

--- a/src/orchestration/epoch-orchestrator.ts
+++ b/src/orchestration/epoch-orchestrator.ts
@@ -9,7 +9,7 @@ import { NodeSplitter } from '../types/node-splitter.js';
 import { EventStream } from '../types/event-stream.js';
 import { NodePruner } from '../types/node-pruner.js';
 import { NodeStats } from '../types/node-stats.js';
-import { isDefined } from '../utilities/is-defined.js';
+import { isDefined } from '../utilities/type-guards.js';
 import { NodeRegistry } from '../service/node-registry.js';
 import { WorkingMemoryBuffer } from '../service/working-memory-buffer.js';
 import { UserInputSensor } from '../sensor/user-input-sensor.js';

--- a/src/sensor/coarse-location-sensor.ts
+++ b/src/sensor/coarse-location-sensor.ts
@@ -1,4 +1,5 @@
 import { Sensor } from '../types/sensor.js';
+import { isDefined } from '../utilities/type-guards.js';
 
 export interface CoarseLocation {
   readonly city?: string;
@@ -40,9 +41,7 @@ export class CoarseLocationSensor implements Sensor {
       this.readString(this.location.description),
       ...this.formatAdditionalFields(this.location.additionalFields),
     ];
-    const parts = [...placeParts, ...extraParts].filter(
-      (part): part is string => part !== undefined,
-    );
+    const parts = [...placeParts, ...extraParts].filter(isDefined);
 
     if (parts.length === 0) {
       return 'not configured';

--- a/src/service/llm-distiller.ts
+++ b/src/service/llm-distiller.ts
@@ -3,7 +3,12 @@ import { DistillationProps, Distiller } from '../types/distiller.js';
 import { Message, MessageRole } from '../types/message.js';
 import { ToolCall, ToolDefinition } from '../types/tool.js';
 import { formatMessagePayload } from '../utilities/action-request.js';
-import { isDefined } from '../utilities/is-defined.js';
+import {
+  isDefined,
+  isRecord,
+  isUniqueIntegerArray,
+  isUniqueStringArray,
+} from '../utilities/type-guards.js';
 
 export interface LlmDistillerProps {
   readonly provider: Provider;
@@ -213,19 +218,6 @@ const synthesisFromToolCall = (
     ...(actionRequests.length === 0 ? {} : { actionRequests }),
   };
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const isUniqueIntegerArray = (value: unknown): value is number[] =>
-  Array.isArray(value) &&
-  value.every((entry) => Number.isInteger(entry)) &&
-  new Set(value).size === value.length;
-
-const isUniqueStringArray = (value: unknown): value is string[] =>
-  Array.isArray(value) &&
-  value.every((entry) => typeof entry === 'string') &&
-  new Set(value).size === value.length;
 
 const MESSAGE_ROLE_LABEL: Record<MessageRole, string> = {
   'working-memory': 'WORKING MEMORY',

--- a/src/service/llm-relevance-filter.ts
+++ b/src/service/llm-relevance-filter.ts
@@ -3,7 +3,7 @@ import { Provider } from '../types/provider.js';
 import { AttentionGate } from '../types/attention-gate.js';
 import { Message } from '../types/message.js';
 import { WorkingMemory } from '../types/working-memory.js';
-import { isDefined } from '../utilities/is-defined.js';
+import { isDefined } from '../utilities/type-guards.js';
 import { formatMessagePayload } from '../utilities/action-request.js';
 
 export interface LlmRelevanceFilterProps {

--- a/src/service/node-registry.ts
+++ b/src/service/node-registry.ts
@@ -2,6 +2,7 @@ import { Node } from '../types/node.js';
 import { MemoryNode } from '../node/memory-node.js';
 import { NodeStats } from '../types/node-stats.js';
 import { EventStream } from '../types/event-stream.js';
+import { isMemoryNode } from '../utilities/type-guards.js';
 
 const ZERO_STATS: NodeStats = {
   epochsAlive: 0,
@@ -69,9 +70,7 @@ export class NodeRegistry {
   }
 
   public memoryNodes(): MemoryNode[] {
-    return this.all().filter(
-      (node): node is MemoryNode => node.kind === 'memory',
-    );
+    return this.all().filter(isMemoryNode);
   }
 
   /** Non-memory nodes (tools, sensors) that feed context into the workspace. */

--- a/src/service/static-node-pruner.ts
+++ b/src/service/static-node-pruner.ts
@@ -1,6 +1,7 @@
 import { NodePruner } from '../types/node-pruner.js';
 import { NodeStats } from '../types/node-stats.js';
 import { Node } from '../types/node.js';
+import { hasDefinedProperty } from '../utilities/type-guards.js';
 
 export interface StaticNodePrunerProps {
   /**
@@ -42,10 +43,8 @@ export class StaticNodePruner implements NodePruner {
     // attendant undefined checks) downstream.
     const eligible = nodes
       .map((node) => ({ node, stat: stats.get(node.id) }))
-      .filter(
-        (entry): entry is { node: Node<T>; stat: NodeStats } =>
-          entry.stat !== undefined && entry.stat.epochsAlive >= minEpochsAlive,
-      );
+      .filter(hasDefinedProperty('stat'))
+      .filter((entry) => entry.stat.epochsAlive >= minEpochsAlive);
 
     const underperforming = eligible.filter((entry) =>
       this.isUnderperforming(entry.stat),

--- a/src/utilities/action-request.ts
+++ b/src/utilities/action-request.ts
@@ -1,5 +1,6 @@
 import { ActionRequest, Message } from '../types/message.js';
 import { ToolCall, ToolDefinition } from '../types/tool.js';
+import { isRecord } from './type-guards.js';
 
 export const ACTION_REQUEST_TOOL_NAME = 'request_node_action';
 
@@ -80,6 +81,3 @@ export const formatMessagePayload = (
   [message.content, formatActionRequests(message.actionRequests)]
     .filter((part) => part.length > 0)
     .join('\n');
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/src/utilities/is-defined.ts
+++ b/src/utilities/is-defined.ts
@@ -1,3 +1,0 @@
-export const isDefined = <T>(item: T | undefined): item is T => {
-  return typeof item !== 'undefined';
-};

--- a/src/utilities/is-strict-eligible.ts
+++ b/src/utilities/is-strict-eligible.ts
@@ -1,3 +1,5 @@
+import { isRecord } from './type-guards.js';
+
 /**
  * Determines whether a JSON Schema can safely be sent to the OpenAI Responses
  * API with `strict: true`.
@@ -70,6 +72,3 @@ export const isStrictEligible = (schema: unknown): boolean => {
   // strict requirements.
   return true;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/src/utilities/session-loader.ts
+++ b/src/utilities/session-loader.ts
@@ -12,6 +12,7 @@ import {
   PersistedMcpServerSummaries,
 } from '../types/mcp-server-summary.js';
 import { ACTIVE_GOAL_FILE_NAME, ActiveGoal } from '../types/goal.js';
+import { isRecord } from './type-guards.js';
 
 export interface LoadedSession {
   readonly nodes: Node<'memory'>[];
@@ -148,9 +149,6 @@ export const SessionLoader = {
     };
   },
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 const normalizeNodeStats = (stats: unknown): NodeStats => {
   if (!isRecord(stats)) {

--- a/src/utilities/session-saver.ts
+++ b/src/utilities/session-saver.ts
@@ -1,5 +1,4 @@
 import { EventStream } from '../types/event-stream.js';
-import { MemoryNode } from '../node/memory-node.js';
 import * as fs from 'node:fs';
 import path from 'node:path';
 import {
@@ -7,6 +6,7 @@ import {
   PersistedMcpServerSummaries,
 } from '../types/mcp-server-summary.js';
 import { ACTIVE_GOAL_FILE_NAME } from '../types/goal.js';
+import { hasErrorCode, isMemoryNode } from './type-guards.js';
 
 export const SessionSaver = {
   saveMcpServerSummaries: (props: {
@@ -32,9 +32,7 @@ export const SessionSaver = {
     eventStream.subscribe({
       topicName: 'orchestrator/node-added',
       receiver: (event) => {
-        const memoryNodes = event.addedNodes.filter(
-          (node): node is MemoryNode => node.kind === 'memory',
-        );
+        const memoryNodes = event.addedNodes.filter(isMemoryNode);
         memoryNodes.forEach((node) =>
           fs.writeFileSync(
             path.join(nodesDirectory, `${node.id}.json`),
@@ -78,7 +76,7 @@ export const SessionSaver = {
           try {
             fs.unlinkSync(path.join(nodesDirectory, `${id}.json`));
           } catch (error) {
-            if (!isMissingFileError(error)) {
+            if (!hasErrorCode(error, 'ENOENT')) {
               eventStream.reportError?.({
                 source: 'SessionSaver',
                 message: `Failed to remove the saved node ${id}.`,
@@ -119,9 +117,3 @@ export const SessionSaver = {
     });
   },
 };
-
-const isMissingFileError = (error: unknown): boolean =>
-  typeof error === 'object' &&
-  error !== null &&
-  'code' in error &&
-  error.code === 'ENOENT';

--- a/src/utilities/type-guards.test.ts
+++ b/src/utilities/type-guards.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasDefinedProperty,
+  hasErrorCode,
+  isDefined,
+  isMemoryNode,
+  isRecord,
+  isToolCall,
+  isUniqueIntegerArray,
+  isUniqueStringArray,
+} from './type-guards.js';
+import type { Node } from '../types/node.js';
+
+const node = (kind: string): Node<string> => ({
+  id: `${kind}-node`,
+  kind,
+  status: 'idle',
+  context: '',
+  sendMessage: async () => undefined,
+});
+
+describe('type guards', () => {
+  it('narrows defined values without discarding other falsy values', () => {
+    expect([undefined, 0, '', false].filter(isDefined)).toEqual([0, '', false]);
+  });
+
+  it('recognizes records but rejects null, arrays, and primitives', () => {
+    expect(isRecord({ key: 'value' })).toBe(true);
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord([])).toBe(false);
+    expect(isRecord('value')).toBe(false);
+  });
+
+  it('recognizes unique integer arrays', () => {
+    expect(isUniqueIntegerArray([1, 2])).toBe(true);
+    expect(isUniqueIntegerArray([1, 1])).toBe(false);
+    expect(isUniqueIntegerArray([1, 1.5])).toBe(false);
+    expect(isUniqueIntegerArray('1,2')).toBe(false);
+  });
+
+  it('recognizes unique string arrays', () => {
+    expect(isUniqueStringArray(['a', 'b'])).toBe(true);
+    expect(isUniqueStringArray(['a', 'a'])).toBe(false);
+    expect(isUniqueStringArray(['a', 1])).toBe(false);
+    expect(isUniqueStringArray('a,b')).toBe(false);
+  });
+
+  it('narrows nodes by their discriminator', () => {
+    const memoryNodes = [node('memory'), node('tool')].filter(isMemoryNode);
+
+    expect(memoryNodes.map(({ id }) => id)).toEqual(['memory-node']);
+  });
+
+  it('recognizes only complete function tool calls', () => {
+    expect(
+      isToolCall({
+        id: 'call-1',
+        type: 'function',
+        function: { name: 'search', arguments: '{}' },
+      }),
+    ).toBe(true);
+    expect(isToolCall(null)).toBe(false);
+    expect(
+      isToolCall({
+        id: '',
+        type: 'function',
+        function: { name: 'search', arguments: '{}' },
+      }),
+    ).toBe(false);
+    expect(
+      isToolCall({
+        id: 'call-1',
+        type: 'custom',
+        function: { name: 'search', arguments: '{}' },
+      }),
+    ).toBe(false);
+    expect(isToolCall({ id: 'call-1', type: 'function' })).toBe(false);
+    expect(
+      isToolCall({
+        id: 'call-1',
+        type: 'function',
+        function: { name: '', arguments: '{}' },
+      }),
+    ).toBe(false);
+    expect(
+      isToolCall({
+        id: 'call-1',
+        type: 'function',
+        function: { name: 'search', arguments: {} },
+      }),
+    ).toBe(false);
+  });
+
+  it('narrows objects with defined properties', () => {
+    const entries = [{ value: 1 }, { value: undefined }].filter(
+      hasDefinedProperty('value'),
+    );
+
+    expect(entries).toEqual([{ value: 1 }]);
+  });
+
+  it('recognizes matching structured error codes', () => {
+    expect(hasErrorCode({ code: 'ENOENT' }, 'ENOENT')).toBe(true);
+    expect(hasErrorCode({ code: 'EACCES' }, 'ENOENT')).toBe(false);
+    expect(hasErrorCode('ENOENT', 'ENOENT')).toBe(false);
+  });
+});

--- a/src/utilities/type-guards.ts
+++ b/src/utilities/type-guards.ts
@@ -1,0 +1,59 @@
+import type { MemoryNode } from '../node/memory-node.js';
+import type { Node } from '../types/node.js';
+import type { ToolCall } from '../types/tool.js';
+
+/** Narrows an optional value without discarding other falsy values. */
+export const isDefined = <T>(value: T | undefined): value is T =>
+  value !== undefined;
+
+/** Narrows an unknown value to a non-null, non-array object. */
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/** Narrows an unknown value to an array of unique integers. */
+export const isUniqueIntegerArray = (value: unknown): value is number[] =>
+  Array.isArray(value) &&
+  value.every((entry) => Number.isInteger(entry)) &&
+  new Set(value).size === value.length;
+
+/** Narrows an unknown value to an array of unique strings. */
+export const isUniqueStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) &&
+  value.every((entry) => typeof entry === 'string') &&
+  new Set(value).size === value.length;
+
+/** Narrows a polymorphic node to the cognitive MemoryNode implementation. */
+export const isMemoryNode = (node: Node<string>): node is MemoryNode =>
+  node.kind === 'memory';
+
+/** Narrows untrusted provider output to Legion's complete function-call shape. */
+export const isToolCall = (value: unknown): value is ToolCall => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const functionCall = value['function'];
+  return (
+    typeof value['id'] === 'string' &&
+    value['id'].length > 0 &&
+    value['type'] === 'function' &&
+    isRecord(functionCall) &&
+    typeof functionCall['name'] === 'string' &&
+    functionCall['name'].length > 0 &&
+    typeof functionCall['arguments'] === 'string'
+  );
+};
+
+/** Creates a guard for objects whose selected property is not undefined. */
+export const hasDefinedProperty =
+  <K extends PropertyKey>(property: K) =>
+  <T extends Record<K, unknown>>(
+    value: T,
+  ): value is T & { [P in K]-?: Exclude<T[P], undefined> } =>
+    value[property] !== undefined;
+
+/** Narrows an unknown thrown value to an object with a specific error code. */
+export const hasErrorCode = (
+  value: unknown,
+  code: string,
+): value is { readonly code: string } =>
+  isRecord(value) && value['code'] === code;


### PR DESCRIPTION
## Summary
- validate targeted and provider-selected calls against advertised tools and schemas
- reject malformed calls and honor MCP semantic error results with bounded diagnostics
- centralize shared type guards and cover mixed-request edge cases

## Verification
- npm run lint
- npm run build
- npm test (412 tests, 100% coverage)

Closes #100